### PR TITLE
Stop freezing dependencies, at least for now, and only require top-level deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,11 @@
-alembic==1.4.2
-click==7.1.2
-Flask==1.1.2
-Flask-Migrate==2.5.3
-Flask-SQLAlchemy==2.4.1
-Flask-WTF==0.14.3
-itsdangerous==1.1.0
-Jinja2==2.11.2
-Mako==1.1.2
-MarkupSafe==1.1.1
-pytest==5.4.1
-python-dateutil==2.8.1
-python-decouple==3.3
-python-editor==1.0.4
-requests==2.23.0
-six==1.14.0
-SQLAlchemy==1.3.16
-Werkzeug==1.0.1
-WTForms==2.3.1
+Flask
+Flask-Migrate
+Flask-SQLAlchemy
+Flask-WTF
+pytest
+python-decouple
+requests
+six
 
 # install data_convert
 ./data_convert


### PR DESCRIPTION
This makes it easier to drop a dependency and cause its transitive dependencies to disappear as well.