### PR TITLE
Fix error in states endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You'll need to edit the database configuration variables in the .env file to use
 
 Assuming you've done the DB setup, you can run like this (for now using the original template files):
 ```shell
-export FLASK_APP=stories.py
+export FLASK_APP=flask_server.py
 flask run
 ```
 

--- a/app/api/data.py
+++ b/app/api/data.py
@@ -24,7 +24,7 @@ def get_batches():
 @api.route('/data/state/', methods=['GET'])
 def get_states():
     current_app.logger.info('Retrieving all states')
-    states = States.query.all()
+    states = State.query.all()
     return jsonify({
         'states': [state.to_dict() for state in states]
     })

--- a/tests/app/v1_basic_test.py
+++ b/tests/app/v1_basic_test.py
@@ -48,6 +48,18 @@ def test_batch_models(app):
     assert "batches" in resp_json
     assert resp_json['batches'][0]['batch_note'] == 'test'
 
+def test_states(app):
+    with app.app_context():
+        nys = State(state_name='NY', full_name="New York")
+        db.session.add(nys)
+        db.session.commit()
+    
+    client = app.test_client()
+    resp_json = client.get("/api/v1/data/state/").json
+    assert "states" in resp_json
+    assert resp_json['states'][0]['full_name'] == 'New York'
+    assert resp_json['states'][0]['state_name'] == 'NY'
+
 def test_core_data(app):
     with app.app_context():
         nys = State(state_name='NY')
@@ -74,3 +86,4 @@ def test_core_data(app):
     # make sure the batch object also represented here, as a parent row
     assert 'batch' in core_data_returned_row
     assert core_data_returned_row['batch_id'] == core_data_returned_row['batch']['batch_id']
+    


### PR DESCRIPTION
`states = States.query.all()` needed to be `states = State.query.all()`

I added a test for this endpoint and snuck in a fix for the README while I was at it.