### PR TITLE
Run `flask db upgrade` on deployments

### DIFF
--- a/.ebextensions/00_post_migrate.config
+++ b/.ebextensions/00_post_migrate.config
@@ -1,0 +1,21 @@
+# Run `flask db migrate` on the leader instance during deployments
+# based on https://stackoverflow.com/questions/31978961/django-migrations-with-docker-on-aws-elastic-beanstalk
+# This will work as long as we're a single-container application
+
+files:
+  "/opt/elasticbeanstalk/hooks/appdeploy/post/10_post_migrate.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      if [ -f /tmp/leader_only ]
+      then
+        rm /tmp/leader_only
+        docker exec `docker ps --no-trunc -q | head -n 1` flask db upgrade
+      fi
+
+container_commands:
+  01_migrate:
+    command: "touch /tmp/leader_only"
+    leader_only: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV FLASK_APP=flask_server.py
 
 # Necessary Folders
 COPY app ./app
+COPY migrations ./migrations
 
 # Necessary Files
 COPY config.py flask_server.py boot.sh gunicorn.ini ./


### PR DESCRIPTION
This runs `flask db upgrade` inside the Docker container within Elastic Beanstalk on the lead instance