### PR TITLE
Add endpoint authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ dmypy.json
 logs/
 
 *.swp
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ You can run the tests with `python -m pytest` once your environemnt is configure
 All tests are run automatically by CircleCI when you create a PR that connects to master.  Please make
 sure tests run relatively quickly (seconds, not minutes).
 
+## Authentication
+
+Endpoints that create/update data are authenticated with a JWT bearer token. 
+
+To obtain a token, run:
+```shell
+flask auth getToken tokenName
+```
+
+The token is secured by the value of `FLASK_SECRET`, so tokens generated in one environment will not work elsewhere 
+unless they have the same secret (this value should overridden on any server).
+
+To pass a token to the API, include it as a header:
+```Authorization: Bearer <token>
+```
+
+When writing tests that call authenticated endpoints, use the `headers` fixture to obtain a headers object containing a valid token.
+When writing endpoints that require authentication, use the `@jwt_required` decorator.
+
 ## Documents
 
 Design Doc (https://docs.google.com/document/d/16JVr3aQE18BUEgrjf7UwQ7ssgghrYqN0lnCjzkghLV0/edit#heading=h.ng2qoy23i2hp)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To obtain a token, run:
 flask auth getToken tokenName
 ```
 
-The token is secured by the value of `FLASK_SECRET`, so tokens generated in one environment will not work elsewhere 
+The token is secured by the value of `SECRET_KEY`, so tokens generated in one environment will not work elsewhere 
 unless they have the same secret (this value should overridden on any server).
 
 To pass a token to the API, include it as a header:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,6 +6,7 @@ application with a specific config file"""
 from flask import Flask
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
+from flask_jwt_extended import JWTManager
 
 # For the database
 db = SQLAlchemy()
@@ -19,6 +20,10 @@ def create_app(config):
 
     db.init_app(app)
     migrate.init_app(app, db)
+    
+    # setup flask_jwt_extended for authentication
+    app.config['JWT_SECRET_KEY'] = app.config['SECRET_KEY']
+    jwt = JWTManager(app)
 
     # Register our API blueprint
     from app.api import api as api_blueprint

--- a/app/api/data.py
+++ b/app/api/data.py
@@ -4,6 +4,7 @@ from flask import jsonify, request, current_app, abort
 from app.api import api
 from app.models.data import *
 from app import db
+from flask_jwt_extended import jwt_required
 
 ##############################################################################################
 ######################################   Health check      ###################################
@@ -16,6 +17,11 @@ def get_data():
     current_app.logger.debug('This is a debug log')
     return jsonify({'test_data_key': 'test_data_value'})
 
+
+@api.route('/test_auth', methods=['GET'])
+@jwt_required
+def test_auth():
+    return jsonify({'user': 'authenticated'}),200
 
 ##############################################################################################
 ######################################   Batches      ########################################
@@ -39,6 +45,7 @@ def get_batches():
 
 
 @api.route('/batches', methods=['POST'])
+@jwt_required
 def post_core_data():
     """
     Workhorse POST method for core data

--- a/app/auth/auth_cli.py
+++ b/app/auth/auth_cli.py
@@ -1,0 +1,10 @@
+""" Create authentication tokens """
+from flask_jwt_extended import create_access_token
+
+def getToken(name):
+    """"
+    Defines a `flask auth getToken` command-line interface to generate an API key
+    The key is secured by the current environment's SECRET_KEY 
+    """
+    access_token = create_access_token(identity=name)
+    return access_token

--- a/config.py
+++ b/config.py
@@ -21,6 +21,8 @@ class LocalPSQLConfig:
     SQLALCHEMY_RECORD_QUERIES = True
 
     SECRET_KEY = env_conf("SECRET_KEY", cast=str, default="12345")
+    # by default, access tokens do not expire
+    JWT_ACCESS_TOKEN_EXPIRES = env_conf('JWT_ACCESS_TOKEN_EXPIRES', cast=int, default=False) 
 
     @staticmethod
     def init_app(app):

--- a/flask_server.py
+++ b/flask_server.py
@@ -23,7 +23,7 @@ app = create_app(config_dict[env_config]())
 # More custom commands can be added to flasks CLI here(for running tests and
 # other stuff)
 
-# register a custom command to get authenticaiton tokens
+# register a custom command to get authentication tokens
 auth_cli = AppGroup('auth')
 @auth_cli.command("getToken")
 @click.argument('name')

--- a/flask_server.py
+++ b/flask_server.py
@@ -3,7 +3,10 @@ stuff happens. You will always want to point your applications like Gunicorn
 to this file, which will pick up the app to run their servers.
 """
 from app import create_app, db
+from app.auth.auth_cli import getToken
 from decouple import config
+from flask.cli import AppGroup
+import click
 
 import config as configs
 
@@ -20,9 +23,11 @@ app = create_app(config_dict[env_config]())
 # More custom commands can be added to flasks CLI here(for running tests and
 # other stuff)
 
-
-@app.cli.command()
-def deploy():
-    """Run deployment tasks"""
-    # e.g. this _used_ to be where a database migration would run via `upgrade()`
-    pass
+# register a custom command to get authenticaiton tokens
+auth_cli = AppGroup('auth')
+@auth_cli.command("getToken")
+@click.argument('name')
+def getToken_cli(name):
+   click.echo(getToken(name))
+   
+app.cli.add_command(auth_cli)

--- a/flask_server.py
+++ b/flask_server.py
@@ -31,3 +31,9 @@ def getToken_cli(name):
    click.echo(getToken(name))
    
 app.cli.add_command(auth_cli)
+
+@app.cli.command()
+def deploy():
+    """Run deployment tasks"""
+    # e.g. this _used_ to be where a database migration would run via `upgrade()`
+    pass

--- a/flask_server.py
+++ b/flask_server.py
@@ -20,6 +20,10 @@ config_dict = {
 
 app = create_app(config_dict[env_config]())
 
+# outside of development or testing, require a real SECRET_KEY to be set
+if env_config != "develop" and env_config != "testing":
+    assert app.config['SECRET_KEY'] != "12345", "You must set a secure SECRET_KEY"
+
 # More custom commands can be added to flasks CLI here(for running tests and
 # other stuff)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pytz
 requests
 six
 testing.postgresql
+flask_jwt_extended

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pytz
 requests
 six
 testing.postgresql
-flask_jwt_extended
+flask-jwt-extended

--- a/tests/app/auth_test.py
+++ b/tests/app/auth_test.py
@@ -1,5 +1,5 @@
 """
-Authenticaiton tests
+Authentication tests
 """
 import pytest
 

--- a/tests/app/auth_test.py
+++ b/tests/app/auth_test.py
@@ -1,0 +1,58 @@
+"""
+Authenticaiton tests
+"""
+import pytest
+
+from app.auth.auth_cli import getToken
+from flask import json, jsonify
+from flask_jwt_extended import decode_token
+
+def test_getToken_cli(app):
+    with app.app_context():
+        # generate a token and make sure it comes out valid
+        token = getToken('test_username')
+        assert token
+    
+        decoded = decode_token(token)
+        assert(decoded['identity'] == 'test_username')
+        
+        # confirm that changing the secret key results in an authentication error
+        old_key = app.config['JWT_SECRET_KEY']
+        app.config['JWT_SECRET_KEY'] = 'adifferentkey'
+        with pytest.raises(Exception, match="Signature verification failed"):
+            decoded = decode_token(token)
+        assert(decoded['identity'] == 'test_username')
+        app.config['JWT_SECRET_KEY'] = old_key
+        
+def test_auth(app, headers):
+    """
+    make various requests to the test_auth endpoint with invalid and valid tokens
+    """
+    client = app.test_client()
+    resp = client.get('/api/v1/test_auth')
+    # should fail because this request lacks an authorizaiton header
+    assert resp.status_code == 401 
+    
+    bad_headers = {
+        'Authorization': 'Bearer {}'.format('this_is_not_a_valid_token')
+    }
+    resp = client.get('/api/v1/test_auth', headers=bad_headers)
+    # should fail because the token is invalid
+    assert resp.status_code == 422    
+    
+    with app.app_context(): 
+        bad_headers = {
+          'Authorization': 'Bearer {}'.format(getToken('test_username'))
+        }
+        old_key = app.config['JWT_SECRET_KEY']
+        app.config['JWT_SECRET_KEY'] = 'adifferentkey'
+        resp = client.get('/api/v1/test_auth', headers=bad_headers)
+        # should fail because the token was generated against the wrong secret key
+        assert resp.status_code == 422
+        app.config['JWT_SECRET_KEY'] = old_key
+    
+    resp = client.get('/api/v1/test_auth', headers=headers)
+    # should pass because this is a valid token
+    assert resp.status_code == 200
+    assert resp.json['user'] == 'authenticated'
+    

--- a/tests/app/auth_test.py
+++ b/tests/app/auth_test.py
@@ -30,7 +30,7 @@ def test_auth(app, headers):
     """
     client = app.test_client()
     resp = client.get('/api/v1/test_auth')
-    # should fail because this request lacks an authorizaiton header
+    # should fail because this request lacks an authorization header
     assert resp.status_code == 401 
     
     bad_headers = {

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from app import create_app, db
+from app.auth.auth_cli import getToken
 
 import testing.postgresql
 
@@ -13,6 +14,8 @@ class TestingPostgresqlConfig:
         return self.test_db.url()
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    
+    SECRET_KEY = '12345'
 
     @staticmethod
     def init_app(app):
@@ -28,3 +31,14 @@ def app():
        db.create_all()
 
     yield app
+
+@pytest.fixture
+def headers(app):
+    with app.app_context():
+        auth_token = getToken('testing')
+        
+    headers = {
+        'Authorization': 'Bearer {}'.format(auth_token)
+    }
+    
+    yield headers

--- a/tests/app/v1_basic_test.py
+++ b/tests/app/v1_basic_test.py
@@ -19,7 +19,7 @@ def test_get_test(app):
     assert "test_data_key" in data 
     assert data["test_data_key"] == "test_data_value" 
 
-def test_post_core_data(app):
+def test_post_core_data(app, headers):
     client = app.test_client()
 
     example_filename = os.path.join(os.path.dirname(__file__), 'data.json')
@@ -28,7 +28,8 @@ def test_post_core_data(app):
     resp = client.post(
         "/api/v1/batches",
         data=payload_json_str,
-        content_type='application/json')
+        content_type='application/json', 
+        headers=headers)
     assert resp.status_code == 201
 
     # we should've written 5 states, 4 core data rows, 1 batch
@@ -43,7 +44,7 @@ def test_post_core_data(app):
     # assert batch data has rows attached to it
     assert len(resp.json['batches'][0]['coreData']) == 4
 
-def test_post_core_data_updating_state(app):
+def test_post_core_data_updating_state(app, headers):
     with app.app_context():
         nys = State(state='AK', name='Alaska')
         db.session.add(nys)
@@ -67,7 +68,9 @@ def test_post_core_data_updating_state(app):
     resp = client.post(
         "/api/v1/batches",
         data=payload_json_str,
-        content_type='application/json')
+        content_type='application/json',
+        headers=headers)
+    assert resp.status_code == 201
 
     # check that the last POST call updated the Alaska info, adding a "twitter" field from test file
     resp = client.get('/api/v1/public/states/info')

--- a/tests/app/v1_basic_test.py
+++ b/tests/app/v1_basic_test.py
@@ -25,6 +25,14 @@ def test_post_core_data(app, headers):
     example_filename = os.path.join(os.path.dirname(__file__), 'data.json')
     with open(example_filename) as f:
         payload_json_str = f.read()
+
+    # attempt to post data without an auth token
+    resp = client.post(
+        "/api/v1/batches",
+        data=payload_json_str,
+        content_type='application/json')
+    assert resp.status_code == 401 # should fail with an authentication error
+
     resp = client.post(
         "/api/v1/batches",
         data=payload_json_str,


### PR DESCRIPTION
- Require a bearer token for endpoints that create/update data
- Add explanation to the README
- Add a `flask auth getToken` CLI command to obtain a token
- Add a test fixture to make authenticated calls in tests

The additions to the README pretty much explain how this works practically. A few notes:

- There's a matching component for this to send an authentication token from the spreadsheet
- I went ahead and used [JWT Tokens](https://jwt.io/introduction/) despite us not really taking full advantage of them at this point. For the moment, any valid token signed against the secret key will be accepted, and we're not differentiating levels of access or other payload data. However, this design will allow us in the future to have goodies like tokens with different privilege levels and a revoked tokens list.
- Currently, tokens never expire. This relies on our ability to not leak the token in the Apps Script's config file. I believe only authorized team members can view the Apps Script on the sheet, but this needs to be confirmed.
- All valid tokens can be revoked by changing the secret key
- This is broadly tested (things that are supposed to require a valid token fail if one isn't supplied), but not rigorously audited from a security standpoint
- [ ] When this is deployed to a server, the `SECRET_KEY` environment variable must be configured with a secret or nothing will be secure