### PR TITLE
Follow-up patch for authentication

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -51,6 +51,7 @@ def get_batch_by_id(id):
 
 
 @api.route('/batches/<int:id>/publish', methods=['POST'])
+@jwt_required
 def publish_batch(id):
     current_app.logger.info('Received request to publish batch %d' % id)
     batch = Batch.query.get_or_404(id)

--- a/tests/app/public_test.py
+++ b/tests/app/public_test.py
@@ -25,7 +25,7 @@ def test_get_states(app):
     assert respjson[0]["pum"] == False
     assert respjson[0]["notes"] == 'Testing123'
 
-def test_get_states_daily(app):
+def test_get_states_daily(app, headers):
     # post some test data
     client = app.test_client()
 
@@ -38,7 +38,8 @@ def test_get_states_daily(app):
     resp = client.post(
         "/api/v1/batches",
         data=payload_json_str,
-        content_type='application/json')
+        content_type='application/json',
+        headers=headers)
     assert resp.status_code == 201
 
     resp = client.get("/api/v1/public/states/daily")
@@ -48,6 +49,8 @@ def test_get_states_daily(app):
 
     # publish it, make sure the data comes back
     resp = client.post('/api/v1/batches/1/publish')
+    assert resp.status_code == 401 # should fail without authentication
+    resp = client.post('/api/v1/batches/1/publish', headers=headers)
     assert resp.status_code == 201
 
     resp = client.get("/api/v1/public/states/daily")

--- a/tests/app/v1_basic_test.py
+++ b/tests/app/v1_basic_test.py
@@ -111,7 +111,7 @@ def test_get_batches(app):
     assert resp.json['batchId'] == 1
     assert resp.json['batchNote'] == 'test1'
 
-def test_publish_batch(app):
+def test_publish_batch(app, headers):
     with app.app_context():
         # write 2 batches
         bat1 = Batch(batchNote='test1', createdAt=datetime.now(),
@@ -131,7 +131,7 @@ def test_publish_batch(app):
         assert batch['isPublished'] == False
 
     # publish the 2nd batch
-    resp = client.post('/api/v1/batches/2/publish')
+    resp = client.post('/api/v1/batches/2/publish', headers=headers)
     assert resp.status_code == 201
     # this should've returned the published batch
     assert resp.json['batchId'] == 2


### PR DESCRIPTION
- Fix the test failures
- Require authentication to publish a batch
- Add authentication to publishing tests