### PR TITLE
Make auth tokens never expire in all environments

### DIFF
--- a/config.py
+++ b/config.py
@@ -53,6 +53,8 @@ class Testing:
     SQLALCHEMY_RECORD_QUERIES = True
 
     SECRET_KEY = env_conf("SECRET_KEY", cast=str, default="12345")
+    # by default, access tokens do not expire
+    JWT_ACCESS_TOKEN_EXPIRES = env_conf('JWT_ACCESS_TOKEN_EXPIRES', cast=int, default=False)
 
     @staticmethod
     def init_app(app):
@@ -83,6 +85,8 @@ class Develop:
     # DEBUG = True
     # API configurations
     SECRET_KEY = env_conf("SECRET_KEY", cast=str, default="12345")
+    # by default, access tokens do not expire
+    JWT_ACCESS_TOKEN_EXPIRES = env_conf('JWT_ACCESS_TOKEN_EXPIRES', cast=int, default=False)
 
     @staticmethod
     def init_app(app):


### PR DESCRIPTION
Just a really small change to make sure we don't generate short-lived expiring access tokens if we're in a different environment like the default one, like I did earlier.