### PR TITLE
Stop setting database environment variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,6 @@ jobs:
       - image: circleci/python:3.6.9
         environment:
           PIPENV_VENV_IN_PROJECT: true
-          DATABASE_HOST: 127.0.0.1
-          DATABASE_NAME: test
-          DATABASE_PORT: 5432
-          DATABASE_USER: postgres
-          DATABASE_PASS: postgres
     steps:
       - run: sudo apt-get update
       - run: sudo apt-get install postgresql


### PR DESCRIPTION
I think these stopped being necessary when the unit tests started using testing.postgresql and they just never got deleted.

Not a big deal, but I'm trying to ramp up on how this all holds together again and this confused me :)