### PR TITLE
Use public APIs to test us_daily

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -1,7 +1,6 @@
 """Registers the necessary routes for the core data model. """
 import flask
 
-from flask import current_app, jsonify
 from app.api import api
 from app.models.data import *
 from app import db
@@ -18,15 +17,15 @@ from sqlalchemy import func, and_
 
 @api.route('/test', methods=['GET'])
 def get_data():
-    current_app.logger.info('Retrieving all data: placeholder')
-    current_app.logger.debug('This is a debug log')
-    return jsonify({'test_data_key': 'test_data_value'})
+    flask.current_app.logger.info('Retrieving all data: placeholder')
+    flask.current_app.logger.debug('This is a debug log')
+    return flask.jsonify({'test_data_key': 'test_data_value'})
 
 
 @api.route('/test_auth', methods=['GET'])
 @jwt_required
 def test_auth():
-    return jsonify({'user': 'authenticated'}),200
+    return flask.jsonify({'user': 'authenticated'}),200
 
 ##############################################################################################
 ######################################   Batches      ########################################
@@ -35,11 +34,11 @@ def test_auth():
 
 @api.route('/batches', methods=['GET'])
 def get_batches():
-    current_app.logger.info('Retrieving all batches')
+    flask.current_app.logger.info('Retrieving all batches')
     batches = Batch.query.all()
     # for each batch, attach its coreData rows
     
-    return jsonify({
+    return flask.jsonify({
         'batches': [batch.to_dict() for batch in batches]
     })
 
@@ -47,14 +46,14 @@ def get_batches():
 @api.route('/batches/<int:id>', methods=['GET'])
 def get_batch_by_id(id):
     batch = Batch.query.get_or_404(id)
-    current_app.logger.info('Returning batch %d' % id)
-    return jsonify(batch.to_dict())
+    flask.current_app.logger.info('Returning batch %d' % id)
+    return flask.jsonify(batch.to_dict())
 
 
 @api.route('/batches/<int:id>/publish', methods=['POST'])
 @jwt_required
 def publish_batch(id):
-    current_app.logger.info('Received request to publish batch %d' % id)
+    flask.current_app.logger.info('Received request to publish batch %d' % id)
     batch = Batch.query.get_or_404(id)
 
     # if batch is already published, fail out
@@ -65,7 +64,7 @@ def publish_batch(id):
     batch.publishedAt = datetime.utcnow()   # set publish time to now
     db.session.add(batch)
     db.session.commit()
-    return jsonify(batch.to_dict()), 201
+    return flask.jsonify(batch.to_dict()), 201
 
 
 ##############################################################################################
@@ -81,7 +80,7 @@ def post_core_data():
 
     Requirements: 
     """
-    current_app.logger.info('Got a post request!')
+    flask.current_app.logger.info('Got a post request!')
     payload = flask.request.json  # this is a dict
 
     # test the input data
@@ -94,7 +93,7 @@ def post_core_data():
 
     # we construct the batch from the push context
     context = payload['context']
-    current_app.logger.info('Creating new batch from context: %s' % context)
+    flask.current_app.logger.info('Creating new batch from context: %s' % context)
     batch = Batch(**context)
     db.session.add(batch)
     db.session.flush()  # this sets the batch ID, which we need for corresponding coreData objects
@@ -105,11 +104,11 @@ def post_core_data():
     for state_dict in state_dicts: 
         state_pk = state_dict['state']
         if db.session.query(State).get(state_pk) is not None:
-            current_app.logger.info('Updating state row from info: %s' % state_dict)
+            flask.current_app.logger.info('Updating state row from info: %s' % state_dict)
             db.session.query(State).filter_by(state=state_pk).update(state_dict)
             state_objects.append(db.session.query(State).get(state_pk))  # return updated state
         else:
-            current_app.logger.info('Creating new state row from info: %s' % state_dict)
+            flask.current_app.logger.info('Creating new state row from info: %s' % state_dict)
             state = State(**state_dict)
             db.session.add(state)
             state_objects.append(state)
@@ -120,14 +119,14 @@ def post_core_data():
     core_data_dicts = payload['coreData']
     core_data_objects = []
     for core_data_dict in core_data_dicts:
-        current_app.logger.info('Creating new core data row: %s' % core_data_dict)
+        flask.current_app.logger.info('Creating new core data row: %s' % core_data_dict)
         core_data_dict['batchId'] = batch.batchId
         core_data = CoreData(**core_data_dict)
         db.session.add(core_data)
         core_data_objects.append(core_data)
 
     db.session.commit()
-    return jsonify({
+    return flask.jsonify({
         'batch': batch.to_dict(),
         'coreData': [core_data.to_dict() for core_data in core_data_objects],
         'states': [state.to_dict() for state in state_objects]

--- a/app/api/data.py
+++ b/app/api/data.py
@@ -1,6 +1,7 @@
 """Registers the necessary routes for the core data model. """
+import flask
 
-from flask import jsonify, request, current_app, abort
+from flask import current_app, jsonify
 from app.api import api
 from app.models.data import *
 from app import db
@@ -81,14 +82,15 @@ def post_core_data():
     Requirements: 
     """
     current_app.logger.info('Got a post request!')
-    payload = request.json  # this is a dict
+    payload = flask.request.json  # this is a dict
 
     # test the input data
-    # TODO: return a status 400 (or maybe 422) with an array of validation errors when assertions
-    # like these fail.
-    assert 'context' in payload, "Payload requires 'context' field"
-    assert 'states' in payload, "Payload requires 'states' field"
-    assert 'coreData' in payload, "Payload requires 'coreData' field"
+    if 'context' not in payload:
+        return flask.Response("Payload requires 'context' field", status=400)
+    if 'states' not in payload:
+        return flask.Response("Payload requires 'states' field", status=400)
+    if 'coreData' not in payload:
+        return flask.Response("Payload requires 'coreData' field", status=400)
 
     # we construct the batch from the push context
     context = payload['context']


### PR DESCRIPTION
I was trying to get a feel for what the API looks like (to figure out what the revision API should look like) and I was struggling to understand it, so it was useful to have the tests go through the public API rather than hitting the database directly.

Does this seem reasonable? I'm happy to close this back out now that I have a better grasp, but I think it might be nice to be going through the public API anyway.