### PR TITLE
Fixing the issue where a core data POST request would fail

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -120,12 +120,18 @@ def post_core_data_json(payload):
         db.session.add(core_data)
         core_data_objects.append(core_data)
 
-    db.session.commit()
-    return flask.jsonify({
+    db.session.flush()
+
+    # construct the JSON before committing the session, since sqlalchemy objects behave weirdly
+    # once the session has been committed
+    json_to_return = {
         'batch': batch.to_dict(),
         'coreData': [core_data.to_dict() for core_data in core_data_objects],
-        'states': [state.to_dict() for state in state_objects]
-    }), 201
+        'states': [state.to_dict() for state in state_objects],
+    }
+
+    db.session.commit()
+    return flask.jsonify(json_to_return), 201
 
 
 @api.route('/batches', methods=['POST'])

--- a/tests/app/public_test.py
+++ b/tests/app/public_test.py
@@ -191,11 +191,10 @@ def test_get_states_daily_for_state(app, headers):
     assert len(resp.json) == 2
 
     for day_data in resp.json:
-        day = parser.parse(day_data['date']).day
-        assert day in [24, 25]
-        if day == 25:
+        assert day_data['date'] in ['20200525', '20200524']
+        if day_data['date'] == '20200525':
             assert day_data['positive'] == 20
             assert day_data['negative'] == 5
-        elif day == 24:
+        elif day_data['date'] == '20200524':
             assert day_data['positive'] == 15
             assert day_data['negative'] == 4


### PR DESCRIPTION
... with a large mysterious uninformative error: no longer trying to access sqlalchemy object properties after the DB session commit.

Also fixed a couple other things:
- the coreData date is now an actual date, not a datetime with timezones
- added ability to specify the string representation of a field for use by the to_dict() serialization
- "date" is now serialized as e.g. "20200601", the way the public API serves it