### PR TITLE
Return the full exception details on 500 server errors

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -33,4 +33,9 @@ def create_app(config):
     from app.utils import utils as utils_blueprint
     app.register_blueprint(utils_blueprint)
 
+    # register an error handler to return full exceptions for server errors
+    @app.errorhandler(500)
+    def internal_server_error(e):
+        return str(e.original_exception), 500
+
     return app

--- a/tests/app/v1_basic_test.py
+++ b/tests/app/v1_basic_test.py
@@ -248,3 +248,15 @@ def test_edit_core_data(app, headers):
             assert day_data['positive'] == 16
             assert day_data['negative'] == 4
 
+def test_push_with_validation_error(app, headers):
+    client = app.test_client()
+
+    bad_data = daily_push_ny_wa_today()
+    bad_data["coreData"][0]["negative"] = "this is a string"
+    resp = client.post(
+        "/api/v1/batches",
+        data=json.dumps(bad_data),
+        content_type='application/json',
+        headers=headers)
+    assert resp.status_code == 500
+    assert "invalid input syntax" in str(resp.data)


### PR DESCRIPTION
We need more specific error messages for common types of errors, especially data validation errors, but as a general/stopgap measure, I wanted to see how it would work to setup a general error handler for all 500 server errors to return at least the underlying exception, since that usually reveals the problem and saves us all a trip through the logs.

Here's an example of what it looks like in the sheet (this is purposefully using a DB that doesn't recognize that column to provoke an undefined column error). Rather ugly, but maybe it's at least more useful than a generic 500 internal server error?

![Coronavirus_numbers_by_state__CovidTracking__DEV_COPY__-_Google_Sheets](https://user-images.githubusercontent.com/918245/85654275-f0ba1a80-b662-11ea-9641-15d7119437bd.jpg)
