### PR TITLE
Remove leading 0 from lastUpdateEt date format

### DIFF
--- a/app/models/data.py
+++ b/app/models/data.py
@@ -191,7 +191,7 @@ class CoreData(db.Model, DataMixin):
         # in the public API
         if self.lastUpdateTime is not None:
             return self.lastUpdateTime.astimezone(pytz.timezone('US/Eastern')).strftime(
-                "%-m/%d/%Y %H:%M")
+                "%-m/%-d/%Y %H:%M")
         else:
             return None
 

--- a/tests/app/model_test.py
+++ b/tests/app/model_test.py
@@ -29,7 +29,7 @@ def test_core_data_model(app):
         db.session.add(nys)
         db.session.flush()
 
-        now_utc = datetime(2020, 5, 14, 20, 3, tzinfo=pytz.UTC)
+        now_utc = datetime(2020, 5, 4, 20, 3, tzinfo=pytz.UTC)
         core_data_row = CoreData(
             lastUpdateIsoUtc=now_utc.isoformat(), dateChecked=now_utc.isoformat(),
             date=datetime.today(), state='NY', batchId=bat.batchId,
@@ -60,7 +60,7 @@ def test_core_data_model(app):
 
         # doing this crazy thing because the offset between UTC and EST varies depending on the date
         hour_in_et = now_utc.astimezone(pytz.timezone('US/Eastern')).hour
-        assert core_data_row.lastUpdateEt == '5/14/2020 %d:03' % hour_in_et
+        assert core_data_row.lastUpdateEt == '5/4/2020 %d:03' % hour_in_et
         
         # check that the Batch object is attached to this CoreData object
         assert core_data_row.batch == batch


### PR DESCRIPTION
For parity with existing public API

`5/4/2020 00:00` and not `5/04/2020 00:00`