### PR TITLE
Refactor slacknotifier—add notify_slack_error()

### DIFF
--- a/app/utils/slacknotifier.py
+++ b/app/utils/slacknotifier.py
@@ -16,6 +16,7 @@ def should_call_slack():
     return current_app.config["SLACK_API_TOKEN"] and current_app.config["SLACK_CHANNEL"]
 
 def notify_slack(message):
+    """Send `message` to the Slack channel configured in the environment config"""
     try:
         if should_call_slack():
             client().chat_postMessage(
@@ -26,6 +27,28 @@ def notify_slack(message):
         # just log Slack failures but don't break on them
         current_app.logger.error(e.response["error"])
 
+
+def notify_slack_error(message, source):
+    """Send error message `message` to the Slack channel configured in the environment config.
+    The error is delivered to Slack as a file for visual distinctiveness and to provide an expanding
+    view for long exceptions without cluttering the channel.
+    Args:
+        message (str): Error message
+        source (str): The operation or API endpoint causing the error (e.g. `post_core_data`)
+    """
+    try:
+        if should_call_slack():
+            client().files_upload(
+                channels=channel(),
+                content=message,
+                filetype='text',
+                title='Error details',
+                initial_comment=f"*:rotating_light: Error in {source}*"
+            )
+    except SlackApiError as slack_error:
+        current_app.logger.error(slack_error.response["error"])
+
+
 def exceptions_to_slack(function):
     """A decorator that catches any exceptions from the passed in function
     and sends them to Slack before re-raising them. This allows us to control
@@ -35,16 +58,6 @@ def exceptions_to_slack(function):
         try:
             return function(*args, **kwargs)
         except Exception as e:
-            try:
-                if should_call_slack():
-                    client().files_upload(
-                        channels=channel(),
-                        content=str(e),
-                        filetype='text',
-                        title='Error details',
-                        initial_comment=f"*Error in {function.__name__}*"
-                    )
-            except SlackApiError as slack_error:
-                current_app.logger.error(slack_error.response["error"])
+            notify_slack_error(str(e), function.__name__)
             raise e  # raise the original exception again
     return wrapper

--- a/tests/app/slacknotifier_test.py
+++ b/tests/app/slacknotifier_test.py
@@ -16,10 +16,13 @@ def test_slack(app, slack_mock):
         notify_slack("test")
         assert slack_mock.chat_postMessage.call_count == 1
 
+        notify_slack_error("missing context", "post_core_data")
+        assert slack_mock.files_upload.call_count == 1
+
         # trigger a a function that raises an exception and ensure slack is notified
         @exceptions_to_slack
         def error_function():
             return 42 / 0
         with pytest.raises(ZeroDivisionError):
             error_function()
-        assert slack_mock.files_upload.call_count == 1
+        assert slack_mock.files_upload.call_count == 2


### PR DESCRIPTION
Provide a handy hook to report errors to Slack that aren’t exceptions