### PR TITLE
Make totalTestResults never return undefined

### DIFF
--- a/app/models/data.py
+++ b/app/models/data.py
@@ -228,7 +228,9 @@ class CoreData(db.Model, DataMixin):
         # Calculated value (positive + negative) of total test results.
         # For consistency with public API, treating a negative null as 0
         if self.negative is None:
-            return self.positive
+            return self.positive or 0
+        if self.positive is None:
+            return self.negative or 0
         return self.positive + self.negative
 
     # Converts the input to a string and returns parsed datetime.date object

--- a/tests/app/model_test.py
+++ b/tests/app/model_test.py
@@ -68,4 +68,19 @@ def test_core_data_model(app):
         assert len(batch.coreData) == 1
         assert batch.coreData[0] == core_data_row
 
+def test_total_test_results(app):
+    with app.app_context():
+        now_utc = datetime(2020, 5, 4, 20, 3, tzinfo=pytz.UTC)
+        core_data_row = CoreData(
+            lastUpdateIsoUtc=now_utc.isoformat(), dateChecked=now_utc.isoformat(),
+            date=datetime.today(), state='NY')
 
+        assert core_data_row.totalTestResults == 0
+
+        core_data_row.positive = 25
+        assert core_data_row.totalTestResults == 25
+        core_data_row.positive = None
+        core_data_row.negative = 5
+        assert core_data_row.totalTestResults == 5
+        core_data_row.positive = 25
+        assert core_data_row.totalTestResults == 30


### PR DESCRIPTION
Have totalTestResults return 0 instead of undefined, for parity with the public API.

I _think_ this is the right behavior, but am not entirely sure. This should all be getting replaced with new logic for totalTestResults soon enough anyway.