### PR TITLE
edit_states_daily: move # rows edited to response

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -353,7 +353,6 @@ def edit_core_data_from_states_daily():
         'changedDates': changed_dates_str,
         'numRowsEdited': len(changed_dates),
         'user': get_jwt_identity(),
-        'shiftLead': batch.shiftLead,
         'coreData': [core_data.to_dict() for core_data in core_data_objects],
     }
 

--- a/app/api/data.py
+++ b/app/api/data.py
@@ -345,12 +345,15 @@ def edit_core_data_from_states_daily():
     # which dates got changed?
     start = sorted(changed_dates)[0].strftime('%-m/%-d/%y')
     end = sorted(changed_dates)[-1].strftime('%-m/%-d/%y')
-    changed_dates_str = start if start == end else '%s - %s (%d rows)' % (start, end, len(changed_dates))
+    changed_dates_str = start if start == end else '%s - %s' % (start, end)
 
     json_to_return = {
         'batch': batch.to_dict(),
         'changedFields': list(changed_fields),
         'changedDates': changed_dates_str,
+        'numRowsEdited': len(changed_dates),
+        'user': get_jwt_identity(),
+        'shiftLead': batch.shiftLead,
         'coreData': [core_data.to_dict() for core_data in core_data_objects],
     }
 

--- a/tests/app/v1_basic_test.py
+++ b/tests/app/v1_basic_test.py
@@ -330,7 +330,6 @@ def test_edit_core_data_from_states_daily(app, headers, slack_mock):
     assert resp.json['changedDates'] == '5/20/20 - 5/25/20'
     assert resp.json['numRowsEdited'] == 2
     assert resp.json['user'] == 'testing'
-    assert resp.json['shiftLead'] == 'test'
 
     # test that sending an edit batch with multiple states fails
     resp = client.post(

--- a/tests/app/v1_basic_test.py
+++ b/tests/app/v1_basic_test.py
@@ -327,7 +327,10 @@ def test_edit_core_data_from_states_daily(app, headers, slack_mock):
         content_type='application/json',
         headers=headers)
     assert resp.json['changedFields'] == ['inIcuCurrently']
-    assert resp.json['changedDates'] == '5/20/20 - 5/25/20 (2 rows)'
+    assert resp.json['changedDates'] == '5/20/20 - 5/25/20'
+    assert resp.json['numRowsEdited'] == 2
+    assert resp.json['user'] == 'testing'
+    assert resp.json['shiftLead'] == 'test'
 
     # test that sending an edit batch with multiple states fails
     resp = client.post(


### PR DESCRIPTION
Add numRowsEdited response parameter and remove that value from the date string
Add user and shiftLead response parameters while we’re at it

Turns out I was being overly clever when I suggested including the count of rows edited in the date string. Addresses the server side of #120. Will need a client-side adjustment to ship these values to the Data Quality Log.