### PR TITLE
Add state to slack edit notification

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -358,7 +358,7 @@ def edit_core_data_from_states_daily():
 
     db.session.commit()
     notify_slack(
-        f"*Pushed edit batch #{batch.batchId}* (user: {batch.shiftLead})\n"
+        f"*Pushed and published edit batch #{batch.batchId}*. state: {state_to_edit}. (user: {batch.shiftLead})\n"
         f"{batch.batchNote}")
 
     return flask.jsonify(json_to_return), 201

--- a/tests/app/v1_basic_test.py
+++ b/tests/app/v1_basic_test.py
@@ -285,6 +285,7 @@ def test_edit_core_data_from_states_daily(app, headers, slack_mock):
         headers=headers)
     assert resp.status_code == 201
     assert slack_mock.chat_postMessage.call_count == 3
+    assert "state: NY" in slack_mock.chat_postMessage.call_args[1]['text']
     batch_id = resp.json['batch']['batchId']
     assert resp.json['batch']['user'] == 'testing'
     # we've changed positive and removed inIcuCurrently, so both should count as changed


### PR DESCRIPTION
#124 — just adding e.g. "state: NY" to the Slack notification for `/batches/edit_states_daily`