### PR TITLE
Send the full backtrace to slack instead of just the exception error message

### DIFF
--- a/app/utils/slacknotifier.py
+++ b/app/utils/slacknotifier.py
@@ -1,4 +1,5 @@
 """Notify Slack about errors and publishing events"""
+import traceback
 
 from slack import WebClient
 from slack.errors import SlackApiError
@@ -58,6 +59,6 @@ def exceptions_to_slack(function):
         try:
             return function(*args, **kwargs)
         except Exception as e:
-            notify_slack_error(str(e), function.__name__)
+            notify_slack_error(traceback.format_exc(), function.__name__)
             raise e  # raise the original exception again
     return wrapper


### PR DESCRIPTION
Not the most important thing in the world, but this sends the full exception backtrace to Slack, since the error alone is fairly unhelpful. Example:

![Slack___database-notifications-staging___COVID-Tracking](https://user-images.githubusercontent.com/918245/90465147-99b14e80-e0c3-11ea-82db-56ed0755b533.jpg)
