### PR TITLE
Adding ability to ingest lastUpdateTime or lastUpdateIsoUtc. 

### DIFF
--- a/tests/app/data.json
+++ b/tests/app/data.json
@@ -572,7 +572,7 @@
          "death":810,
          "deathConfirmed":801,
          "deathProbable":9,
-         "lastUpdateIsoUtc":"2020-06-18T15:00:00.000Z",
+         "lastUpdateTime":"2020-06-18T15:00:00.000Z",
          "privateNotes":"(6/8 QN) Did not update negatives since total tests updated late\n(6/7 HMH) Recoveries updated weekly (not sure which day)\n\n",
          "dataQualityGrade":"B",
          "date":"2020-06-18T04:00:00.000Z"

--- a/tests/app/v1_basic_test.py
+++ b/tests/app/v1_basic_test.py
@@ -53,8 +53,17 @@ def test_post_core_data(app, headers):
     assert resp.json['batches'][0]['user'] == 'testing'
     # assert batch data has rows attached to it
     assert len(resp.json['batches'][0]['coreData']) == 56
+
+    # spot-check a few values
+    assert resp.json['batches'][0]['coreData'][0]['state'] == 'AK'
+    assert resp.json['batches'][0]['coreData'][0]['positive'] == 708
+    # the entry for AK uses lastUpdateIsoUtc
+    assert resp.json['batches'][0]['coreData'][0]['lastUpdateTime'] == '2020-06-18T04:00:00Z'
+
     assert resp.json['batches'][0]['coreData'][1]['state'] == 'AL'
     assert resp.json['batches'][0]['coreData'][1]['recovered'] == 15974
+    # the entry for AL uses lastUpdateTime instead of lastUpdateIsoUtc, confirming it works
+    assert resp.json['batches'][0]['coreData'][1]['lastUpdateTime'] == '2020-06-18T15:00:00Z'
 
 
 def test_post_core_data_updating_state(app, headers):


### PR DESCRIPTION
Also illuminated yet another timezone issue which is fixed in this PR: the string representations of lastUpdateTime and dateChecked were previously outputting the date in the local timezone as a UTC string, so now converting back to UTC before formatting the date string.