### PR TITLE
Add edit diffs, send to Slack

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -10,6 +10,7 @@ from app import db
 from app.api import api
 from app.api.common import states_daily_query
 from app.models.data import *
+from app.utils.editdiff import EditDiff, ChangedValue, ChangedRow
 from app.utils.slacknotifier import notify_slack, notify_slack_error, exceptions_to_slack
 from app.utils.validation import validate_core_data_payload, validate_edit_data_payload
 from app.utils.webhook import notify_webhook
@@ -336,10 +337,14 @@ def edit_core_data_from_states_daily():
     for state_daily_data in latest_daily_data_for_state:
         date_to_data[state_daily_data.date] = state_daily_data
 
-    # check each core data row that the corresponding date/state already exists in published form
+    # keep track of all our changes as we go
     core_data_objects = []
     changed_fields = set()
     changed_dates = set()
+    changed_rows = []
+    new_rows = []
+
+    # check each core data row that the corresponding date/state already exists in published form
     for core_data_dict in payload['coreData']:
         # this state has to be identical to the state from the context
         state = core_data_dict['state']
@@ -371,21 +376,30 @@ def edit_core_data_from_states_daily():
 
             flask.current_app.logger.info('Row for date not found, making new edit row: %s' % date)
             is_edited = True
+            new_rows.append(edited_core_data)
 
         else:
             # this row already exists, but check each value to see if anything changed. Easiest way
-            # to do this is to make a new CoreData and compare it to the existing one
-            
+            # to do this is to make a new CoreData (edited_core_data) and compare it to the existing one
+            row_diffs = []
+
             for field in CoreData.__table__.columns.keys():
                 # we expect batch IDs to be different, skip comparing those
                 if field == 'batchId':
                     continue
                 # for any other field, compare away
-                if getattr(data_for_date, field) != getattr(edited_core_data, field):
+                old = getattr(data_for_date, field)
+                new = getattr(edited_core_data, field)
+                if old != new:
                     changed_fields_for_date.add(field)
                     is_edited = True
+                    row_diffs.append(ChangedValue(field=field, old=old, new=new))
 
-        # if any value in the row is different, make an edit batch
+            # if the row has been edited, save the list of the differences
+            if is_edited:
+                    changed_rows.append(ChangedRow(date=edited_core_data.date, state=state, changed_values=row_diffs))
+
+        # if any value in the row is different or the whole row is new, make an edit batch
         if is_edited:
             db.session.add(edited_core_data)
             core_data_objects.append(edited_core_data)
@@ -412,9 +426,14 @@ def edit_core_data_from_states_daily():
     }
 
     db.session.commit()
+
+    # collect all the diffs for the edits we've made and format them for a slack notification
+    diffs = EditDiff(changed_rows, new_rows)
+    diffs_for_slack = diffs.plain_text_format()
+
     notify_slack(
         f"*Pushed and published edit batch #{batch.batchId}*. state: {state_to_edit}. (user: {batch.shiftLead})\n"
-        f"{batch.batchNote}")
+        f"{batch.batchNote}", diffs_for_slack)
 
     return flask.jsonify(json_to_return), 201
 

--- a/app/api/data.py
+++ b/app/api/data.py
@@ -314,7 +314,7 @@ def edit_core_data_from_states_daily():
     # check that the state is set
     state_to_edit = context.get('state')
     if not state_to_edit:
-        flask.current_app.logger.error("No state specified in batch edit context: %s" % str(e))
+        flask.current_app.logger.error("No state specified in batch edit context: %s" % str(context))
         notify_slack_error(
             'No state specified in batch edit context', 'edit_core_data_from_states_daily')
         return flask.jsonify('No state specified in batch edit context'), 400

--- a/app/api/data.py
+++ b/app/api/data.py
@@ -395,8 +395,8 @@ def edit_core_data_from_states_daily():
                     row_diffs.append(ChangedValue(field=field, old=old, new=new))
 
             # if the row has been edited, save the list of the differences
-            if is_edited:
-                    changed_rows.append(ChangedRow(date=edited_core_data.date, state=state, changed_values=row_diffs))
+            if row_diffs:
+                changed_rows.append(ChangedRow(date=edited_core_data.date, state=state, changed_values=row_diffs))
 
         # if any value in the row is different or the whole row is new, make an edit batch
         if is_edited:

--- a/app/templates/editdiff_plain.txt
+++ b/app/templates/editdiff_plain.txt
@@ -1,0 +1,17 @@
+{%- if new_rows is not none and new_rows|length > 0 -%}
+New rows: {{ new_rows|length }}
+
+{%+ for row in new_rows -%}
+{{row.state}} {{row.date}}
+{%- endfor %}
+
+{%+ endif -%}
+
+Rows edited: {{ changed_rows|length }}
+{%+ for row in changed_rows %}
+{{row.state}} {{row.date}}
+{%- for value in row.changed_values %}
+    {{ value.field }}: {{ value.new }} (was {{ value.old }})
+{%- endfor -%}
+{%- endfor -%}
+

--- a/app/utils/editdiff.py
+++ b/app/utils/editdiff.py
@@ -1,0 +1,32 @@
+import collections
+
+from flask import render_template, Flask
+
+ChangedRow = collections.namedtuple('ChangedRow', 'date state changed_values')
+ChangedValue = collections.namedtuple('ChangedValue', 'field old new')
+
+
+class EditDiff:
+    """An object representing the set of changes made during an edit batch.
+
+    Example:
+        Sample EditDiff::
+            changed_values = [ChangedValue(field="positive", old=123, new=456)]
+            changed_rows = [ChangedRow(date="20200903", state="CA", changed_values=changed_values)]
+            EditDiff(changed_rows, None)
+
+
+    Attributes:
+        changed_rows: a list of `ChangedRow` elements containing each edited row
+        new_rows: a list of newly added rows, expressed as CoreData objects
+    """
+
+    def __init__(self, changed_rows, new_rows):
+        self.changed_rows = changed_rows
+        self.new_rows = new_rows
+
+    def plain_text_format(self):
+        """Return the diff in plain text format.
+
+        The format is maintained in ``app/templates/editdiff.txt``"""
+        return render_template("editdiff_plain.txt", changed_rows=self.changed_rows, new_rows=self.new_rows)

--- a/app/utils/slacknotifier.py
+++ b/app/utils/slacknotifier.py
@@ -6,24 +6,44 @@ from slack.errors import SlackApiError
 from flask import current_app
 import functools
 
+
 def client():
     token = current_app.config["SLACK_API_TOKEN"]
     return WebClient(token=token)
 
+
 def channel():
     return current_app.config["SLACK_CHANNEL"]
+
 
 def should_call_slack():
     return current_app.config["SLACK_API_TOKEN"] and current_app.config["SLACK_CHANNEL"]
 
-def notify_slack(message):
-    """Send `message` to the Slack channel configured in the environment config"""
+
+def notify_slack(message, file_attachment=None):
+    """Send `message` to the Slack channel configured in the environment config
+
+    Args:
+        message (str): message to be sent to Slack
+        file_attachment (str): optional file to be attached to the message inside a thread
+    """
     try:
         if should_call_slack():
-            client().chat_postMessage(
+            response = client().chat_postMessage(
                 channel=channel(),
                 text=message
             )
+
+            # send the attachment, if present, as a thread to the initial message
+            if file_attachment is not None and response.validate() and response.get("ts") is not None:
+                client().files_upload(
+                    channels=channel(),
+                    thread_ts=response.get("ts"),
+                    content=file_attachment,
+                    filetype='text',
+                    title='Changes',
+                    initial_comment=f":ctp-eye:"
+                )
     except SlackApiError as e:
         # just log Slack failures but don't break on them
         current_app.logger.error(e.response["error"])
@@ -54,6 +74,7 @@ def exceptions_to_slack(function):
     """A decorator that catches any exceptions from the passed in function
     and sends them to Slack before re-raising them. This allows us to control
     what endpoints report errors to Slack."""
+
     @functools.wraps(function)
     def wrapper(*args, **kwargs):
         try:
@@ -61,4 +82,5 @@ def exceptions_to_slack(function):
         except Exception as e:
             notify_slack_error(traceback.format_exc(), function.__name__)
             raise e  # raise the original exception again
+
     return wrapper

--- a/tests/app/editdiff_test.py
+++ b/tests/app/editdiff_test.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+
+import pytz
+
+from app import db
+from app.models.data import Batch, State, CoreData
+from app.utils.editdiff import EditDiff, ChangedValue, ChangedRow
+
+
+def test_editdiff(app):
+    with app.app_context():
+        changed_values = [ChangedValue(field="positive", old=123, new=456), ChangedValue(field="negative", old=555, new=666)]
+        changed_rows = [ChangedRow(date="20200903", state="CA", changed_values=changed_values)]
+        ed = EditDiff(changed_rows, None)
+        output = ed.plain_text_format()
+
+        assert "Rows edited: 1" in output
+        assert "CA 20200903" in output
+        assert "positive: 456 (was 123)" in output
+        assert "New rows" not in output
+
+        nys = State(state='NY')
+        bat = Batch(batchNote='test', createdAt=datetime.now(),
+                    isPublished=False, isRevision=False)
+        db.session.add(bat)
+        db.session.add(nys)
+        db.session.flush()
+
+        now_utc = datetime(2020, 5, 4, 20, 3, tzinfo=pytz.UTC)
+        core_data_row = CoreData(
+            lastUpdateIsoUtc=now_utc.isoformat(), dateChecked=now_utc.isoformat(),
+            date=now_utc, state='NY', batchId=bat.batchId,
+            positive=20, negative=5)
+        new_rows = [core_data_row]
+
+        ed = EditDiff(changed_rows, new_rows)
+        output = ed.plain_text_format()
+        assert "Rows edited: 1" in output
+        assert "New rows: 1" in output
+        assert "NY "+now_utc.strftime("%Y-%m-%d") in output

--- a/tests/app/slacknotifier_test.py
+++ b/tests/app/slacknotifier_test.py
@@ -1,7 +1,8 @@
 import pytest
 from app.utils.slacknotifier import *
 
-def test_slack(app, slack_mock):
+
+def test_slack_noop(app, slack_mock):
     with app.app_context():
         app.config["SLACK_API_TOKEN"] = None
         app.config["SLACK_CHANNEL"] = None
@@ -10,19 +11,38 @@ def test_slack(app, slack_mock):
         assert not should_call_slack()
         notify_slack("test")
         assert slack_mock.chat_postMessage.call_count == 0
+        assert slack_mock.files_upload.call_count == 0
 
+
+def test_notify_slack(app, slack_mock):
+    with app.app_context():
         app.config["SLACK_API_TOKEN"] = "token"
         app.config["SLACK_CHANNEL"] = "channel"
         notify_slack("test")
         assert slack_mock.chat_postMessage.call_count == 1
+        assert slack_mock.files_upload.call_count == 0  # no file specified, so no file should be uploaded
 
+        # test notify_slack with a file attachment
+        notify_slack("test2", "this is a file")
+        assert slack_mock.chat_postMessage.call_count == 2
+        assert slack_mock.files_upload.call_count == 1
+        assert "this is a file" == slack_mock.files_upload.call_args[1]['content']
+
+
+def test_notify_slack_error(app, slack_mock):
+    with app.app_context():
         notify_slack_error("missing context", "post_core_data")
         assert slack_mock.files_upload.call_count == 1
+        assert "missing context" == slack_mock.files_upload.call_args[1]['content']
 
+
+def test_slack_exceptions(app, slack_mock):
+    with app.app_context():
         # trigger a a function that raises an exception and ensure slack is notified
         @exceptions_to_slack
         def error_function():
             return 42 / 0
         with pytest.raises(ZeroDivisionError):
             error_function()
-        assert slack_mock.files_upload.call_count == 2
+        assert slack_mock.files_upload.call_count == 1
+        assert "ZeroDivisionError" in slack_mock.files_upload.call_args[1]['content']


### PR DESCRIPTION
Naturally this had to be spread across seven files because why should anything be too simple?

You can see sample output in #database-notifications-staging. I'm very open to adjusting the format to be more readable, but figured this is a good starting point, and it's adaptable if we want to generate markdown for a github issue comment or other outputs.

One question I had is whether we want to store the diff in the batches table, since it's complicated to try to get the same information out of SQL later. And if we do want to store it, whether we should store the formatted string or some programmatic representation of the diff data (I can turn the diff information into JSON and put the JSON in the DB I suppose). 