### PR TITLE
Allow submitting only the fields to update in `edit_states_daily` endpoint

### DIFF
--- a/app/utils/editdiff.py
+++ b/app/utils/editdiff.py
@@ -2,8 +2,25 @@ import collections
 
 from flask import render_template, Flask
 
-ChangedRow = collections.namedtuple('ChangedRow', 'date state changed_values')
 ChangedValue = collections.namedtuple('ChangedValue', 'field old new')
+
+
+class ChangedRow:
+    def __init__(self, date, state, changed_values):
+        ''' Changed values -- ChangedValue type'''
+        self.date = date
+        self.state = state
+        self.changed_values = changed_values
+
+    @property
+    def changed_fields(self):
+        return [c.field for c in self.changed_values]
+
+    def __str__(self):
+        return "ChangedRow({date}, {state}, {changed_values})".format(**self.__dict__)
+
+    def __repr__(self):
+        return self.__str__()
 
 
 class EditDiff:
@@ -30,3 +47,33 @@ class EditDiff:
 
         The format is maintained in ``app/templates/editdiff.txt``"""
         return render_template("editdiff_plain.txt", changed_rows=self.changed_rows, new_rows=self.new_rows)
+
+    @property
+    def changed_fields(self):
+        res = set()
+        for row in self.changed_rows:
+            res.update(row.changed_fields)
+
+        return list(res)
+
+    @property
+    def changed_dates_str(self):
+        '''Which dates changed in this diff'''
+        if self.is_empty():
+            return ""
+
+        changed_dates = [c.date for c in self.changed_rows] + [c.date for c in self.new_rows]
+        changed_dates = sorted(changed_dates)
+        start = changed_dates[0].strftime('%-m/%-d/%y')
+        end = changed_dates[-1].strftime('%-m/%-d/%y')
+        changed_dates_str = start if start == end else '%s - %s' % (start, end)
+        return changed_dates_str
+
+    def size(self):
+        # maybe implement it with len(diff)?
+        res = len(self.changed_rows) if self.changed_rows else 0
+        res += len(self.new_rows) if self.new_rows else 0
+        return res
+
+    def is_empty(self):
+        return not self.changed_rows and not self.new_rows

--- a/tests/app/common.py
+++ b/tests/app/common.py
@@ -48,13 +48,15 @@ WA_YESTERDAY = {
 }
 
 # edit to increase positive count by 1
+# remove inIcuCurrently
 NY_YESTERDAY_EDITED = {
     "state": "NY",
     "lastUpdateIsoUtc": NOW.isoformat(),
     "dateChecked": NOW.isoformat(),
     "date": YESTERDAY,
     "positive": 16,
-    "negative": 4
+    "negative": 4,
+    "inIcuCurrently": None
 }
 
 NY_TODAY_EDITED = {
@@ -190,4 +192,24 @@ def edit_push_multiple_states():
     return {
       "context": ctx,
       "coreData": [NY_YESTERDAY_EDITED.copy(), WA_YESTERDAY.copy()]
+    }
+
+def edit_push_ny_today_empty():
+    ctx = {
+      "dataEntryType": "edit",
+      "shiftLead": "test",
+      "state": "NY",
+      "batchNote": "No changes",
+      "logCategory": "State Updates",
+      "link": "https://example.com"
+    }
+
+    edit_data = {
+        "state": "NY",
+        "date": TODAY
+    }
+
+    return {
+      "context": ctx,
+      "coreData": [edit_data]
     }

--- a/tests/app/common.py
+++ b/tests/app/common.py
@@ -59,6 +59,16 @@ NY_YESTERDAY_EDITED = {
     "inIcuCurrently": None
 }
 
+# edit to increase positive count by 1
+# do not send other fields
+NY_YESTERDAY_PARTIAL_EDIT = {
+    "state": "NY",
+    "lastUpdateIsoUtc": NOW.isoformat(),
+    "dateChecked": NOW.isoformat(),
+    "date": YESTERDAY,
+    "positive": 16
+}
+
 NY_TODAY_EDITED = {
     "state": "NY",
     "lastUpdateIsoUtc": NOW.isoformat(),
@@ -164,6 +174,20 @@ def edit_push_ny_yesterday_change_only_timestamp():
       "coreData": [edit_data]
     }
 
+def edit_push_ny_yesterday_change_only_positive():
+    ctx = {
+      "dataEntryType": "edit",
+      "shiftLead": "test",
+      "state": "NY",
+      "batchNote": "This is an edit test changing only the positive val",
+      "logCategory": "State Updates",
+      "link": "https://example.com"
+    }
+
+    return {
+      "context": ctx,
+      "coreData": [NY_YESTERDAY_PARTIAL_EDIT.copy()]
+    }
 
 def edit_push_ny_today_and_before_yesterday():
     ctx = {


### PR DESCRIPTION
Move the check for differences between submitted and existing values to the data model class.

Enable submitting only the fields to update, without repeating existing values for `/api/v1/batches/edit_states_daily` endpoint. This will be more relevant for automated, or though spreadsheets for workflows such as backfills.
Add a test for this behaviour.

**There are 2 commits in this PR:**
1. *The 1st commit* in this PR is beefing up `editdiff.py` (that I really want to rename to ChangeSet). So that this class, with all the info about the changes generates the field diff and date-range diff, number of changed rows, etc (everything that goes into messages).
1. *The 2nd commit* is to actually add the logic to handle sending only fields for update and not all fields.