### PR TITLE
Special-case totalTestResults to match public API

### DIFF
--- a/app/models/data.py
+++ b/app/models/data.py
@@ -231,6 +231,11 @@ class CoreData(db.Model, DataMixin):
     def totalTestResults(self):
         # Calculated value (positive + negative) of total test results.
         # For consistency with public API, treating a negative null as 0
+
+        # to match the public API, use totalTestEncountersViral for selected states
+        if self.state in ["RI", "CO"]:
+            return self.totalTestEncountersViral or 0
+
         if self.negative is None:
             return self.positive or 0
         if self.positive is None:

--- a/tests/app/model_test.py
+++ b/tests/app/model_test.py
@@ -84,3 +84,15 @@ def test_total_test_results(app):
         assert core_data_row.totalTestResults == 5
         core_data_row.positive = 25
         assert core_data_row.totalTestResults == 30
+
+        # RI and CO have special behavior (use totalTestEncountersViral)
+        core_data_row = CoreData(
+            lastUpdateIsoUtc=now_utc.isoformat(), dateChecked=now_utc.isoformat(),
+            date=datetime.today(), state='RI', positive=25, negative=5, totalTestEncountersViral=33)
+        assert core_data_row.totalTestResults == 33
+        core_data_row.state = 'NY'
+        assert core_data_row.totalTestResults == 30
+        core_data_row.state = 'CO'
+        assert core_data_row.totalTestResults == 33
+        core_data_row.totalTestEncountersViral = None
+        assert core_data_row.totalTestResults == 0


### PR DESCRIPTION
Don't hate me for this, but I'm thinking we should make `totalTestResults` match the public API. This will allow [the comparison tool](https://internal.covidtracking.com/compare) to show blank output, and then we can point to that and say "see, 100% compared" (or actually notice any discrepancies since there won't be known false positives). 

Only change is to special case CO and RI to use a different calculation, just a straight port of the JS function from the API build too to Python.

There's a future task to use `covidTrackingProjectPreferredTotalTestUnits` and `covidTrackingProjectPreferredTotalTestField`, but nobody's ready for that yet, so this just matches the existing behavior of the public API (see [here for that](https://github.com/COVID19Tracking/covid-public-api-build/blob/master/config/sources/states.js#L250)).