### PR TITLE
Config constants and webhook error handling

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -72,7 +72,9 @@ def publish_batch(id):
     db.session.add(batch)
     db.session.commit()
 
-    notify_webhook()
+    res = notify_webhook()
+    if res is not None and (not res or res.status_code != 200):
+        notify_slack_error(f"Failed webhook on batch #{id}", "publish_batch")
 
     notify_slack(f"*Published batch #{id}* (type: {batch.dataEntryType})\n"
                  f"{batch.batchNote}")

--- a/app/utils/webhook.py
+++ b/app/utils/webhook.py
@@ -6,15 +6,26 @@ import requests
 from flask import current_app
 
 def notify_webhook():
+    # TODO: replace this with an annotation that checks that response and makes
+    # a call only on a successful response from the method it annotates
+
     url = current_app.config['API_WEBHOOK_URL']
     if not url: # nothing to do for dev environments without a url set
         return
 
-    response = requests.get(url)
+    try:
+        response = requests.get(url)
+    except Exception as e:
+        current_app.logger.warning(
+            'Request to webhook %s failed returned an error: %s' % (url, str(e)))
+        return False
 
     if response.status_code != 200:
-        raise requests.HTTPError(
-            'Request to webhook %s returned an error %s, the response is:\n%s'
-            % (url, response.status_code, response.text)
-        )
+        # log an error but do not raise an exception
+        # This method would usually run *after a commit*, as a best-effort
+        # method, it should not fail a response to the user
+        current_app.logger.error(
+            'Request to webhook %s finished unsuccessfully: %s, the response is:\n%s'
+            % (url, response.status_code, response.text))
+
     return response

--- a/config.py
+++ b/config.py
@@ -27,9 +27,9 @@ class LocalPSQLConfig:
     # by default, access tokens do not expire
     JWT_ACCESS_TOKEN_EXPIRES = env_conf('JWT_ACCESS_TOKEN_EXPIRES', cast=int, default=False)
 
-    API_WEBHOOK_URL = env_conf('API_WEBHOOK_URL', cast=str, default=None)
-    SLACK_API_TOKEN = env_conf('SLACK_API_TOKEN', cast=str, default=None)
-    SLACK_CHANNEL = env_conf('SLACK_CHANNEL', cast=str, default=None)
+    API_WEBHOOK_URL = env_conf('API_WEBHOOK_URL', cast=str, default='')
+    SLACK_API_TOKEN = env_conf('SLACK_API_TOKEN', cast=str, default='')
+    SLACK_CHANNEL = env_conf('SLACK_CHANNEL', cast=str, default='')
 
     @staticmethod
     def init_app(app):
@@ -59,9 +59,9 @@ class Production:
     # by default, access tokens do not expire
     JWT_ACCESS_TOKEN_EXPIRES = env_conf('JWT_ACCESS_TOKEN_EXPIRES', cast=int, default=False)
 
-    API_WEBHOOK_URL = env_conf('API_WEBHOOK_URL', cast=str, default=None)
-    SLACK_API_TOKEN = env_conf('SLACK_API_TOKEN', cast=str, default=None)
-    SLACK_CHANNEL = env_conf('SLACK_CHANNEL', cast=str, default=None)
+    API_WEBHOOK_URL = env_conf('API_WEBHOOK_URL', cast=str, default='')
+    SLACK_API_TOKEN = env_conf('SLACK_API_TOKEN', cast=str, default='')
+    SLACK_CHANNEL = env_conf('SLACK_CHANNEL', cast=str, default='')
 
     @staticmethod
     def init_app(app):
@@ -96,9 +96,9 @@ class Testing:
     # by default, access tokens do not expire
     JWT_ACCESS_TOKEN_EXPIRES = env_conf('JWT_ACCESS_TOKEN_EXPIRES', cast=int, default=False)
 
-    API_WEBHOOK_URL = env_conf('API_WEBHOOK_URL', cast=str, default=None)
-    SLACK_API_TOKEN = env_conf('SLACK_API_TOKEN', cast=str, default=None)
-    SLACK_CHANNEL = env_conf('SLACK_CHANNEL', cast=str, default=None)
+    API_WEBHOOK_URL = env_conf('API_WEBHOOK_URL', cast=str, default='')
+    SLACK_API_TOKEN = env_conf('SLACK_API_TOKEN', cast=str, default='')
+    SLACK_CHANNEL = env_conf('SLACK_CHANNEL', cast=str, default='')
 
     @staticmethod
     def init_app(app):
@@ -126,9 +126,9 @@ class Develop:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_RECORD_QUERIES = True
 
-    API_WEBHOOK_URL = env_conf('API_WEBHOOK_URL', cast=str, default=None)
-    SLACK_API_TOKEN = env_conf('SLACK_API_TOKEN', cast=str, default=None)
-    SLACK_CHANNEL = env_conf('SLACK_CHANNEL', cast=str, default=None)
+    API_WEBHOOK_URL = env_conf('API_WEBHOOK_URL', cast=str, default='')
+    SLACK_API_TOKEN = env_conf('SLACK_API_TOKEN', cast=str, default='')
+    SLACK_CHANNEL = env_conf('SLACK_CHANNEL', cast=str, default='')
 
     # DEBUG = True
     # API configurations

--- a/tests/app/webhook_test.py
+++ b/tests/app/webhook_test.py
@@ -15,5 +15,10 @@ def test_call_webhook(app, requests_mock):
         assert resp.json() == {'it': 'worked'}
 
         requests_mock.get(url, status_code=500)
-        with pytest.raises(HTTPError):
-            resp = notify_webhook()
+        resp = notify_webhook()
+        assert requests_mock.call_count == 2
+
+        # try with a bad url/error in request
+        requests_mock.register_uri('GET', url, exc=HTTPError),
+        resp = notify_webhook()
+        assert resp == False


### PR DESCRIPTION
This commit changes how some constants are set in the configuration and also makes `notify_webhook` a safe method to use, without raising exceptions.

In configuration, when forcing a config/env variable to be of type string it casts the value to string.
```
API_WEBHOOK_URL = env_conf('API_WEBHOOK_URL', cast=str, default=None)
```
Which means that `None` actually becomes the string `"None"` -- this is the expected default. Changed to empty string.

Next, the exception thrown in `notify_webhook` is replaced with an error or warning logging and returning the response as is (when response exists). Because it is called after a commit (in most cases), failing to send a response to the user if the notify failed seems not appropriate. Later, we could add retries to the call.