### PR TITLE
Edist: add/edit rows only if there are valid fields

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -354,13 +354,22 @@ def edit_core_data_from_states_daily():
             notify_slack_error(error, 'edit_core_data_from_states_daily')
             return flask.jsonify(error), 400
 
+        valid, unknown = CoreData.valid_fields_checker(core_data_dict)
+        if not valid:
+            # there are no fields to add/update
+            flask.current_app.logger.info('Got row without updates, skipping. %r' % core_data_dict)
+            continue
+
+        if unknown:
+            # report unknown fields, we won't fail the request, but should at least log
+            flask.current_app.logger.warning('Got row with unknown field updates. %r' % core_data_dict)
+
         # is there a date for this?
         # check that there exists at least one published row for this date/state
         date = CoreData.parse_str_to_date(core_data_dict['date'])
         data_for_date = date_to_data.get(date)
-        edited_core_data = None
-
         core_data_dict['batchId'] = batch.batchId
+        edited_core_data = None
 
         if not data_for_date:
             # this is a new row: we treat this as a changed date

--- a/tests/app/common.py
+++ b/tests/app/common.py
@@ -237,3 +237,24 @@ def edit_push_ny_today_empty():
       "context": ctx,
       "coreData": [edit_data]
     }
+
+def edit_unknown_fields():
+    ctx = {
+      "dataEntryType": "edit",
+      "shiftLead": "test",
+      "state": "NY",
+      "batchNote": "no data",
+      "logCategory": "State Updates",
+      "link": "https://example.com"
+    }
+
+    edit_data = {
+      "state": "NY",
+      "date": BEFORE_YESTERDAY,
+      "foobar": 1
+    }
+
+    return {
+      "context": ctx,
+      "coreData": [edit_data]
+    }

--- a/tests/app/model_test.py
+++ b/tests/app/model_test.py
@@ -34,7 +34,7 @@ def test_core_data_model(app):
             lastUpdateIsoUtc=now_utc.isoformat(), dateChecked=now_utc.isoformat(),
             date=datetime.today(), state='NY', batchId=bat.batchId,
             positive=20, negative=5)
-        
+
         db.session.add(core_data_row)
         db.session.commit()
 
@@ -61,12 +61,35 @@ def test_core_data_model(app):
         # doing this crazy thing because the offset between UTC and EST varies depending on the date
         hour_in_et = now_utc.astimezone(pytz.timezone('US/Eastern')).hour
         assert core_data_row.lastUpdateEt == '5/4/2020 %d:03' % hour_in_et
-        
+
         # check that the Batch object is attached to this CoreData object
         assert core_data_row.batch == batch
         # also check the relationship in the other direction, that CoreData is attached to the batch
         assert len(batch.coreData) == 1
         assert batch.coreData[0] == core_data_row
+
+def test_core_data_fields():
+    '''This test tests the valid_fields_checker method in CoreData '''
+
+    # There are some consts and assumptions here about what is a field and what isn't.
+    # It's not read dynamically
+
+    valid_fields = ['positive', 'negative']
+    keys = ['state', 'date', 'batchId']
+    unknown_fields = ['moonBaze', 'marsBase', 'kuiperBeltShield']
+
+    valids, unknowns = CoreData.valid_fields_checker(valid_fields + keys + unknown_fields)
+    assert set(valid_fields) == set(valids)
+    assert set(unknown_fields) == set(unknowns)
+
+
+    valids, unknowns = CoreData.valid_fields_checker(valid_fields + keys)
+    assert set(valid_fields) == set(valids)
+    assert len(unknowns) == 0
+
+    valids, unknowns = CoreData.valid_fields_checker(keys)
+    assert len(valids) == 0
+    assert len(unknowns) == 0
 
 def test_total_test_results(app):
     with app.app_context():


### PR DESCRIPTION
This PR updates the behaviour of edit requests: Edit (or insert) requests *have* to contain significant fields to be written to the DB.
I.e., fields other than `state` & `date` have to exist in the request.

Before this change, all the following updates would create an empty row:
1.
```
{ 
  state: RI,
  date: 2020-08-17
}
```
2.
```
{ 
  state: RI,
  date: 2020-08-17,
  non_existing_field: 12
}
```


After this change, none of these updates would write content.
