### PR TITLE
De-jsonifying error messages from the internal API 

### DIFF
--- a/tests/app/auth_test.py
+++ b/tests/app/auth_test.py
@@ -39,7 +39,7 @@ def test_auth(app, headers):
     resp = client.get('/api/v1/test_auth', headers=bad_headers)
     # should fail because the token is invalid and the error message should be informative
     assert resp.status_code == 422
-    assert resp.get_data() == b'Your database password is invalid: did you enter a secret key?'
+    assert resp.data.decode("utf-8") == 'Your database password is invalid: did you enter a secret key?'
     
     with app.app_context(): 
         bad_headers = {


### PR DESCRIPTION
...so that they are actually visible in spreadsheet dialog boxes during a bad push/edit.

Also moving an edit (metadata) test into the edit test file.