### PR TITLE
Fix 204 errors

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -215,6 +215,7 @@ def post_core_data():
 
     return post_result
 
+
 def any_existing_rows(state, date):
     date = CoreData.parse_str_to_date(date)
     existing_rows = db.session.query(CoreData).join(Batch).filter(
@@ -223,21 +224,6 @@ def any_existing_rows(state, date):
         CoreData.date == date).all()
     return len(existing_rows) > 0
 
-# Returns a string with any errors if the payload is invalid, otherwise returns empty string.
-def edit_data_payload_error(payload):
-    # check push context
-    if 'context' not in payload:
-        return "Payload requires 'context' field"
-    if payload['context']['dataEntryType'] != 'edit':
-        return "Payload 'context' must contain data entry type 'edit'"
-    if not payload['context'].get('batchNote'):
-        return "Payload 'context' must contain a batchNote explaining edit"
-
-    # check that edit data exists
-    if 'coreData' not in payload:
-        return "Payload requires 'coreData' field"
-
-    return ''
 
 @api.route('/batches/edit', methods=['POST'])
 @jwt_required

--- a/app/api/data.py
+++ b/app/api/data.py
@@ -408,7 +408,7 @@ def edit_core_data_from_states_daily():
             f"*Received edit batch #{batch.batchId}*. state: {state_to_edit}. (user: {batch.shiftLead})\n"
             f"{batch.batchNote} but no differences detected, data is unchanged", "edit_states_daily")
 
-        return 'Data is unchanged: no edits detected', 204
+        return 'Data is unchanged: no edits detected', 400
 
     json_to_return = {
         'batch': batch.to_dict(),

--- a/tests/app/edit_test.py
+++ b/tests/app/edit_test.py
@@ -134,8 +134,9 @@ def test_edit_core_data_from_states_daily_empty(app, headers, slack_mock):
         content_type='application/json',
         headers=headers)
 
-    assert resp.status_code == 204
-    assert slack_mock.chat_postMessage.call_count == 2 # logging unchanged edit to Slack
+    assert resp.status_code == 400
+    assert slack_mock.chat_postMessage.call_count == 2  # logging unchanged edit to Slack
+    assert "no edits detected" in resp.data.decode("utf-8")
 
 
 def test_edit_core_data_from_states_daily(app, headers, slack_mock):
@@ -347,8 +348,9 @@ def test_edit_core_data_from_states_daily_partial_update(app, headers, slack_moc
         headers=headers)
 
     # verify
-    assert resp.status_code == 204
+    assert resp.status_code == 400
     assert slack_mock.chat_postMessage.call_count == 3
+    assert "no edits detected" in resp.data.decode("utf-8")
 
 def test_edit_with_valid_and_unknown_fields(app, headers, slack_mock):
     ''' Verify that when sending edit (or insert) requests without any fields
@@ -383,5 +385,6 @@ def test_edit_with_valid_and_unknown_fields(app, headers, slack_mock):
         headers=headers)
 
     # verify: nothing was edited
-    assert resp.status_code == 204
+    assert resp.status_code == 400
     assert slack_mock.chat_postMessage.call_count == 2
+    assert "no edits detected" in resp.data.decode("utf-8")


### PR DESCRIPTION
Turns out that an HTTP 204 No Content response can't, per the spec ("A 204 response is terminated by the first empty line after the header fields because it cannot contain a message body") contain a message body at all, so that explains why there was no message body. Changing the error code to 400 so we get a real error message.