### PR TITLE
turn notify_webhook into a decorator, call it after edits

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -58,6 +58,7 @@ def get_batch_by_id(id):
 
 @api.route('/batches/<int:id>/publish', methods=['POST'])
 @jwt_required
+@notify_webhook
 @exceptions_to_slack
 def publish_batch(id):
     flask.current_app.logger.info('Received request to publish batch %d' % id)
@@ -72,10 +73,6 @@ def publish_batch(id):
     db.session.add(batch)
     db.session.commit()
 
-    res = notify_webhook()
-    if res is not None and (not res or res.status_code != 200):
-        notify_slack_error(f"Failed webhook on batch #{id}", "publish_batch")
-
     notify_slack(f"*Published batch #{id}* (type: {batch.dataEntryType})\n"
                  f"{batch.batchNote}")
 
@@ -89,6 +86,7 @@ def publish_batch(id):
 
 @api.route('/states/edit', methods=['POST'])
 @jwt_required
+@notify_webhook
 @exceptions_to_slack
 def edit_state_metadata():
     payload = flask.request.json
@@ -233,6 +231,7 @@ def any_existing_rows(state, date):
 
 @api.route('/batches/edit', methods=['POST'])
 @jwt_required
+@notify_webhook
 @exceptions_to_slack
 def edit_core_data():
     flask.current_app.logger.info('Received a CoreData edit request')
@@ -253,6 +252,7 @@ def edit_core_data():
 
 @api.route('/batches/edit_states_daily', methods=['POST'])
 @jwt_required
+@notify_webhook
 @exceptions_to_slack
 def edit_core_data_from_states_daily():
     payload = flask.request.json

--- a/app/utils/webhook.py
+++ b/app/utils/webhook.py
@@ -1,16 +1,31 @@
 """Used to call out to an external webhook (i.e. the public API build tool)
  when publishing new data to the database. The webhook URL is set in the
  environment with the `API_WEBHOOK_URL` variable"""
-
+import functools
 import requests
 from flask import current_app
 
-def notify_webhook():
-    # TODO: replace this with an annotation that checks that response and makes
-    # a call only on a successful response from the method it annotates
+from app.utils.slacknotifier import notify_slack_error
 
+
+def notify_webhook(func):
+    """Notifies a webhook (defined in the config with "API_WEBHOOK_URL") if the function it wraps is successful.
+    Used to kick off the public API build after data changes."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        value = func(*args, **kwargs)
+
+        # notify the webhook unless the response has a non-default status code and that status code is not successful
+        if not (type(value) == tuple and value[1] >= 300):
+            do_notify_webhook()
+
+        return value
+    return wrapper
+
+
+def do_notify_webhook():
     url = current_app.config['API_WEBHOOK_URL']
-    if not url: # nothing to do for dev environments without a url set
+    if not url:  # nothing to do for dev environments without a url set
         return
 
     try:
@@ -18,6 +33,7 @@ def notify_webhook():
     except Exception as e:
         current_app.logger.warning(
             'Request to webhook %s failed returned an error: %s' % (url, str(e)))
+        notify_slack_error(f"notify_webhook failed: #{str(e)}", "do_notify_webhook")
         return False
 
     if response.status_code != 200:
@@ -27,5 +43,6 @@ def notify_webhook():
         current_app.logger.error(
             'Request to webhook %s finished unsuccessfully: %s, the response is:\n%s'
             % (url, response.status_code, response.text))
+        notify_slack_error(f"notify_webhook failed (#{response.status_code}): #{response.text}", "do_notify_webhook")
 
     return response

--- a/tests/app/webhook_test.py
+++ b/tests/app/webhook_test.py
@@ -1,24 +1,58 @@
 import pytest
 import requests_mock
+from flask import Response
 from requests import HTTPError
 
-from app.utils.webhook import notify_webhook
+from app.api import api
+from app.utils.webhook import do_notify_webhook, notify_webhook
 
 
-def test_call_webhook(app, requests_mock):
+def test_do_notify_webhook(app, requests_mock, slack_mock):
     with app.app_context():
         url = 'http://example.com/web/hook'
         app.config['API_WEBHOOK_URL'] = url
         requests_mock.get(url, json= {'it': 'worked'})
-        resp = notify_webhook()
+        resp = do_notify_webhook()
         assert requests_mock.call_count == 1
         assert resp.json() == {'it': 'worked'}
+        # nothing should be posted to slack for a successful operation
+        assert slack_mock.chat_postMessage.call_count == 0
+        assert slack_mock.files_upload.call_count == 0
 
         requests_mock.get(url, status_code=500)
-        resp = notify_webhook()
+        resp = do_notify_webhook()
         assert requests_mock.call_count == 2
+        # error should be reported to slack
+        assert slack_mock.files_upload.call_count == 1
 
         # try with a bad url/error in request
         requests_mock.register_uri('GET', url, exc=HTTPError),
-        resp = notify_webhook()
-        assert resp == False
+        resp = do_notify_webhook()
+        assert resp is False
+        # error should be reported to slack
+        assert slack_mock.files_upload.call_count == 2
+
+
+def test_webhook_decorator(app, requests_mock, slack_mock):
+    with app.app_context():
+        url = 'http://example.com/web/hook'
+        app.config['API_WEBHOOK_URL'] = url
+        requests_mock.get(url, json= {'it': 'worked'})
+
+        @api.route('/test_webhook', methods=['GET'])
+        @notify_webhook
+        def successful_function():
+            return "blah blah", 201
+        assert requests_mock.call_count == 0
+        successful_function()
+        assert requests_mock.call_count == 1
+        assert slack_mock.files_upload.call_count == 0
+
+        @api.route('/test_webhook_fail', methods=['GET'])
+        def unsuccessful_function():
+            return "blah blah", 500
+        assert requests_mock.call_count == 1
+        unsuccessful_function()
+        # webhook should not be called because the operation failed
+        assert requests_mock.call_count == 1
+        assert slack_mock.files_upload.call_count == 0


### PR DESCRIPTION
We're not currently calling notify_webhook() after data is edited, which could result in a lag before the edits go live. This turns it into a decorator that's triggered whenever an operation is successful and applies it to edit endpoints as well.