### PR TITLE
add totalTestResultsSource to CoreData

### DIFF
--- a/app/models/data.py
+++ b/app/models/data.py
@@ -243,13 +243,18 @@ class CoreData(db.Model, DataMixin):
             return None
 
     @hybrid_property
+    def totalTestResultsSource(self):
+        """The source column used to calculate totalTestResults, equal to the state's totalTestResultsFieldDbColumn"""
+        return self.state_obj.totalTestResultsFieldDbColumn
+
+    @hybrid_property
     def totalTestResults(self):
         """Calculated value of total test results
 
         This value is determined based on the state's totalTestResultsFieldDbColumn, with empty cells converted to 0.
         If a CoreData column name is specified, that column will be used for totalTestResults.
         Alternatively, the 'posNeg' keyword can be used to indicate totalTestResults = (positive+negative)"""
-        column = self.state_obj.totalTestResultsFieldDbColumn
+        column = self.totalTestResultsSource
 
         if column == 'posNeg':  # posNeg: calculated value (positive + negative) of total test results.
             if self.negative is None:

--- a/tests/app/model_test.py
+++ b/tests/app/model_test.py
@@ -122,6 +122,7 @@ def test_total_test_results(app):
         db.session.commit()
 
         # test posNeg behavior
+        assert core_data_row.totalTestResultsSource == 'posNeg'
         assert core_data_row.totalTestResults == 0
         core_data_row.positive = 25
         assert core_data_row.totalTestResults == 25
@@ -134,6 +135,7 @@ def test_total_test_results(app):
         # now set the state to use a column for totalTestResultsFieldDbColumn
         nys.totalTestResultsFieldDbColumn = 'totalTestEncountersViral'
         db.session.commit()
+        assert core_data_row.totalTestResultsSource == 'totalTestEncountersViral'
         assert core_data_row.totalTestResults == 0
         core_data_row.totalTestEncountersViral = 55
         assert core_data_row.totalTestResults == 55
@@ -143,6 +145,7 @@ def test_total_test_results(app):
 
         nys.totalTestResultsFieldDbColumn = 'totalTestsViral'
         db.session.commit()
+        assert core_data_row.totalTestResultsSource == 'totalTestsViral'
         assert core_data_row.totalTestResults == 0
         core_data_row.totalTestsViral = 75
         assert core_data_row.totalTestResults == 75


### PR DESCRIPTION
The public API build tool needs an accurate value for totalTestResultsSource, so this exposes it, just the column (or posNeg) we use to calculate totalTestResults.