### PR TITLE
totalTestResults adjustments

### DIFF
--- a/app/api/csv.py
+++ b/app/api/csv.py
@@ -147,7 +147,6 @@ def get_states_daily_csv():
             CSVColumn(label="Deaths (confirmed)", model_column="deathConfirmed"),
             CSVColumn(label="Deaths (probable)", model_column="deathProbable"),
             CSVColumn(label="Total PCR Tests (People)", model_column="totalTestsPeopleViral"),
-            CSVColumn(label="Total Test Results", model_column=None, blank=True),
             CSVColumn(label="Probable Cases", model_column="probableCases"),
             CSVColumn(label="Total Test Encounters (PCR)", model_column="totalTestEncountersViral"),
             CSVColumn(label="Total Antibody Tests (People)", model_column="totalTestsPeopleAntibody"),
@@ -158,7 +157,9 @@ def get_states_daily_csv():
             CSVColumn(label="Negative Antigen Tests (People)", model_column="negativeTestsPeopleAntigen"),
             CSVColumn(label="Total Antigen Tests", model_column="totalTestsAntigen"),
             CSVColumn(label="Positive Antigen Tests", model_column="positiveTestsAntigen"),
-            CSVColumn(label="Negative Antigen Tests", model_column="negativeTestsAntigen")])
+            CSVColumn(label="Negative Antigen Tests", model_column="negativeTestsAntigen"),
+            CSVColumn(label="_posNeg", model_column=None, blank=True),
+            CSVColumn(label="Total Test Results", model_column="totalTestResults")])
 
     return make_csv_response(columns, reformatted_data)
 

--- a/app/models/data.py
+++ b/app/models/data.py
@@ -269,7 +269,7 @@ class CoreData(db.Model, DataMixin):
                 return self.negative or 0
             return self.positive + self.negative
         else:  # column is a coreData column, return its value, converting none to 0
-            value = getattr(self, column) or 0
+            value = getattr(self, column)
             return value
 
     # Converts the input to a string and returns parsed datetime.date object

--- a/tests/app/model_test.py
+++ b/tests/app/model_test.py
@@ -136,16 +136,16 @@ def test_total_test_results(app):
         nys.totalTestResultsFieldDbColumn = 'totalTestEncountersViral'
         db.session.commit()
         assert core_data_row.totalTestResultsSource == 'totalTestEncountersViral'
-        assert core_data_row.totalTestResults == 0
+        assert core_data_row.totalTestResults is None
         core_data_row.totalTestEncountersViral = 55
         assert core_data_row.totalTestResults == 55
         core_data_row.totalTestEncountersViral = None
-        assert core_data_row.totalTestResults == 0
+        assert core_data_row.totalTestResults is None
         core_data_row.totalTestEncountersViral = 100
 
         nys.totalTestResultsFieldDbColumn = 'totalTestsViral'
         db.session.commit()
         assert core_data_row.totalTestResultsSource == 'totalTestsViral'
-        assert core_data_row.totalTestResults == 0
+        assert core_data_row.totalTestResults is None
         core_data_row.totalTestsViral = 75
         assert core_data_row.totalTestResults == 75


### PR DESCRIPTION
It's been 12 minutes since we changed how totalTestResults work, so it's time to do it again.

- Do not force value to 0 if the source column is null
- Add totalTestResults to CSV for parity since it’s now no longer hidden in the public sheet

I validated this by comparing the CSV output from my local machine (off the prod dataset) with the totalTestResults column in the current public sheet: all identical.