### PR TITLE
fix: add newlines between new rows in edit diffs

### DIFF
--- a/app/templates/editdiff_plain.txt
+++ b/app/templates/editdiff_plain.txt
@@ -1,7 +1,7 @@
 {%- if new_rows is not none and new_rows|length > 0 -%}
 New rows: {{ new_rows|length }}
 
-{%+ for row in new_rows -%}
+{%+ for row in new_rows %}
 {{row.state}} {{row.date}}
 {%- endfor %}
 


### PR DESCRIPTION
Before: `HI 2020-03-06HI 2020-03-05HI 2020-03-04`

After: that, but with newlines in between each entry