### PR TITLE
❌ [CSV] column management and queries for "latest" data for states and US

### DIFF
--- a/app/api/csv.py
+++ b/app/api/csv.py
@@ -1,4 +1,3 @@
-import collections
 import csv
 from datetime import timedelta
 from io import StringIO
@@ -10,10 +9,8 @@ from flask_restful import inputs
 
 from app.api import api
 from app.api.common import us_daily_query, states_daily_query, State
+from app.api.csv_columns import *
 
-CSVColumn = collections.namedtuple('Column', 'label model_column blank')
-# set default value of the blank parameter to false, all other params are required
-CSVColumn.__new__.__defaults__ = (False, )
 """Represents the recipe to generate a column of CSV output data. 
 
 This maps a model column name to a CSV column name. An ordered list of CSVColumns can be passed to `make_csv_response`
@@ -110,56 +107,10 @@ def get_states_daily_csv():
         # add the row to the output
         reformatted_data.append(result_dict)
 
-    columns = []
-
-    if request.endpoint != 'api.states_current':
-        columns.append(CSVColumn(label="Date", model_column="date"))
-
-    columns.extend([
-        CSVColumn(label="State", model_column="state"),
-        CSVColumn(label="Positive", model_column="positive"),
-        CSVColumn(label="Negative", model_column="negative"),
-        CSVColumn(label="Pending", model_column="pending"),
-        CSVColumn(label="Hospitalized – Currently", model_column="hospitalizedCurrently"),
-        CSVColumn(label="Hospitalized – Cumulative", model_column="hospitalizedCumulative"),
-        CSVColumn(label="In ICU – Currently", model_column="inIcuCurrently"),
-        CSVColumn(label="In ICU – Cumulative", model_column="inIcuCumulative"),
-        CSVColumn(label="On Ventilator – Currently", model_column="onVentilatorCurrently"),
-        CSVColumn(label="On Ventilator – Cumulative", model_column="onVentilatorCumulative"),
-        CSVColumn(label="Recovered", model_column="recovered"),
-        CSVColumn(label="Deaths", model_column="death")])
-
-    if request.endpoint == 'api.states_current':
-        columns.extend([
-            CSVColumn(label="Last Update ET", model_column="lastUpdateEt"),
-            CSVColumn(label="Check Time (ET)", model_column="dateChecked")])
-    else:
-        columns.extend([
-            CSVColumn(label="Data Quality Grade", model_column="dataQualityGrade"),
-            CSVColumn(label="Last Update ET", model_column="lastUpdateEt"),
-            CSVColumn(label="Total Antibody Tests", model_column="totalTestsAntibody"),
-            CSVColumn(label="Positive Antibody Tests", model_column="positiveTestsAntibody"),
-            CSVColumn(label="Negative Antibody Tests", model_column="negativeTestsAntibody"),
-            CSVColumn(label="Total Tests (PCR)", model_column="totalTestsViral"),
-            CSVColumn(label="Positive Tests (PCR)", model_column="positiveTestsViral"),
-            CSVColumn(label="Negative Tests (PCR)", model_column="negativeTestsViral"),
-            CSVColumn(label="Positive Cases (PCR)", model_column="positiveCasesViral"),
-            CSVColumn(label="Deaths (confirmed)", model_column="deathConfirmed"),
-            CSVColumn(label="Deaths (probable)", model_column="deathProbable"),
-            CSVColumn(label="Total PCR Tests (People)", model_column="totalTestsPeopleViral"),
-            CSVColumn(label="Probable Cases", model_column="probableCases"),
-            CSVColumn(label="Total Test Encounters (PCR)", model_column="totalTestEncountersViral"),
-            CSVColumn(label="Total Antibody Tests (People)", model_column="totalTestsPeopleAntibody"),
-            CSVColumn(label="Positive Antibody Tests (People)", model_column="positiveTestsPeopleAntibody"),
-            CSVColumn(label="Negative Antibody Tests (People)", model_column="negativeTestsPeopleAntibody"),
-            CSVColumn(label="Total Antigen Tests (People)", model_column="totalTestsPeopleAntigen"),
-            CSVColumn(label="Positive Antigen Tests (People)", model_column="positiveTestsPeopleAntigen"),
-            CSVColumn(label="Negative Antigen Tests (People)", model_column="negativeTestsPeopleAntigen"),
-            CSVColumn(label="Total Antigen Tests", model_column="totalTestsAntigen"),
-            CSVColumn(label="Positive Antigen Tests", model_column="positiveTestsAntigen"),
-            CSVColumn(label="Negative Antigen Tests", model_column="negativeTestsAntigen"),
-            CSVColumn(label="_posNeg", model_column=None, blank=True),
-            CSVColumn(label="Total Test Results", model_column="totalTestResults")])
+    columns = STATES_CURRENT
+    if request.endpoint == 'api.states_daily':
+        columns = STATES_DAILY
+    columns = select(columns)
 
     return make_csv_response(columns, reformatted_data)
 
@@ -176,23 +127,8 @@ def get_us_daily_csv():
     if request.endpoint == 'api.us_current':
         us_data_by_date = us_data_by_date[:1]
 
-    columns = []
-
-    if request.endpoint != 'api.us_current':
-        columns.extend([CSVColumn(label="Date", model_column="date"),
-                        CSVColumn(label="States", model_column="states")])
-
-    columns.extend([
-        CSVColumn(label="Positive", model_column="positive"),
-        CSVColumn(label="Negative", model_column="negative"),
-        CSVColumn(label="Pending", model_column="pending"),
-        CSVColumn(label="Hospitalized – Currently", model_column="hospitalizedCurrently"),
-        CSVColumn(label="Hospitalized – Cumulative", model_column="hospitalizedCumulative"),
-        CSVColumn(label="In ICU – Currently", model_column="inIcuCurrently"),
-        CSVColumn(label="In ICU – Cumulative", model_column="inIcuCumulative"),
-        CSVColumn(label="On Ventilator – Currently", model_column="onVentilatorCurrently"),
-        CSVColumn(label="On Ventilator – Cumulative", model_column="onVentilatorCumulative"),
-        CSVColumn(label="Recovered", model_column="recovered"),
-        CSVColumn(label="Deaths", model_column="death")])
-
+    columns = US_CURRENT_COLUMNS
+    if request.endpoint == 'api.us_daily':
+        columns = US_DAILY_COLUMNS
+    columns = select(columns)
     return make_csv_response(columns, us_data_by_date)

--- a/app/api/csv_columns.py
+++ b/app/api/csv_columns.py
@@ -1,0 +1,158 @@
+# This is strictly data, but JSON has no comments
+# and YAML requires additional dependencies
+
+''' Mapping from DB column name to CSV display name
+'''
+
+import collections
+
+from sqlalchemy.sql import literal_column, func
+from enum import Enum
+from app.models.data import Batch, CoreData, State
+
+
+CSVColumn = collections.namedtuple('Column', 'label model_column blank')
+# set default value of the blank parameter to false, all other params are required
+CSVColumn.__new__.__defaults__ = (False, )
+
+class Literal:
+    def __init__(self, name):
+        self.name = name
+
+COLUMNS_DISPLAY_NAMES = {
+    # TODO: replace strings with column keys
+
+    "date": "Date",
+    "state": "State",
+    "states": "States",
+    "positive": "Positive",
+    "negative": "Negative",
+    "pending": "Pending",
+    "hospitalizedCurrently": "Hospitalized – Currently",
+    "hospitalizedCumulative": "Hospitalized – Cumulative",
+    "inIcuCurrently": "In ICU – Currently",
+    "inIcuCumulative": "In ICU – Cumulative",
+    "onVentilatorCurrently": "On Ventilator – Currently",
+    "onVentilatorCumulative": "On Ventilator – Cumulative",
+    "recovered": "Recovered",
+    "death": "Deaths",
+    "dataQualityGrade": "Data Quality Grade",
+    "lastUpdateEt": "Last Update ET",
+    "totalTestsAntibody": "Total Antibody Tests",
+    "positiveTestsAntibody": "Positive Antibody Tests",
+    "negativeTestsAntibody": "Negative Antibody Tests",
+    "totalTestsViral": "Total Tests (PCR)",
+    "positiveTestsViral": "Positive Tests (PCR)",
+    "negativeTestsViral": "Negative Tests (PCR)",
+    "positiveCasesViral": "Positive Cases (PCR)",
+    "deathConfirmed": "Deaths (confirmed)",
+    "deathProbable": "Deaths (probable)",
+    "totalTestsPeopleViral": "Total PCR Tests (People)",
+    "probableCases": "Probable Cases",
+    "totalTestEncountersViral": "Total Test Encounters (PCR)",
+    "totalTestsPeopleAntibody": "Total Antibody Tests (People)",
+    "positiveTestsPeopleAntibody": "Positive Antibody Tests (People)",
+    "negativeTestsPeopleAntibody": "Negative Antibody Tests (People)",
+    "totalTestsPeopleAntigen": "Total Antigen Tests (People)",
+    "positiveTestsPeopleAntigen": "Positive Antigen Tests (People)",
+    "negativeTestsPeopleAntigen": "Negative Antigen Tests (People)",
+    "totalTestsAntigen": "Total Antigen Tests",
+    "positiveTestsAntigen": "Positive Antigen Tests",
+    "negativeTestsAntigen": "Negative Antigen Tests",
+    "totalTestResults": "Total Test Results",
+}
+
+
+US_CURRENT_COLUMNS = [
+    CoreData.positive,
+    CoreData.negative,
+    CoreData.pending,
+    CoreData.hospitalizedCurrently,
+    CoreData.hospitalizedCumulative,
+    CoreData.inIcuCurrently,
+    CoreData.inIcuCumulative,
+    CoreData.onVentilatorCurrently,
+    CoreData.onVentilatorCumulative,
+    CoreData.recovered,
+    CoreData.death,
+]
+
+
+US_DAILY_COLUMNS = [CoreData.date, Literal("states")] + US_CURRENT_COLUMNS
+
+
+
+STATES_CURRENT = [
+    CoreData.state,
+    CoreData.positive,
+    CoreData.negative,
+    CoreData.pending,
+    CoreData.hospitalizedCurrently,
+    CoreData.hospitalizedCumulative,
+    CoreData.inIcuCurrently,
+    CoreData.inIcuCumulative,
+    CoreData.onVentilatorCurrently,
+    CoreData.onVentilatorCumulative,
+    CoreData.recovered,
+    CoreData.death,
+
+
+    Literal("lastUpdateEt"),
+    #CoreData.lastUpdateEt,
+    CoreData.dateChecked
+]
+
+STATES_DAILY = [
+    #func.to_char(CoreData.date, 'YYYYMMDD').label('date'),
+    CoreData.date,
+    CoreData.state,
+    CoreData.positive,
+    CoreData.negative,
+    CoreData.pending,
+    CoreData.hospitalizedCurrently,
+    CoreData.hospitalizedCumulative,
+    CoreData.inIcuCurrently,
+    CoreData.inIcuCumulative,
+    CoreData.onVentilatorCurrently,
+    CoreData.onVentilatorCumulative,
+    CoreData.recovered,
+    CoreData.death,
+
+    CoreData.dataQualityGrade,
+    #CoreData.lastUpdateEt,
+    Literal("lastUpdateEt"),
+    CoreData.totalTestsAntibody,
+    CoreData.positiveTestsAntibody,
+    CoreData.negativeTestsAntibody,
+    CoreData.totalTestsViral,
+    CoreData.positiveTestsViral,
+    CoreData.negativeTestsViral,
+    CoreData.positiveCasesViral,
+    CoreData.deathConfirmed,
+    CoreData.deathProbable,
+    CoreData.probableCases,
+    CoreData.totalTestEncountersViral,
+    CoreData.totalTestsPeopleAntibody,
+    CoreData.positiveTestsPeopleAntibody,
+    CoreData.negativeTestsPeopleAntibody,
+    CoreData.totalTestsPeopleAntigen,
+    CoreData.positiveTestsPeopleAntigen,
+    CoreData.negativeTestsPeopleAntigen,
+    CoreData.totalTestsAntigen,
+    CoreData.positiveTestsAntigen,
+    CoreData.negativeTestsAntigen,
+
+    # Fake Column
+    literal_column("''").label('_posNeg'),
+
+    #CoreData.totalTestResults
+    Literal("totalTestResults"),
+]
+
+
+def select(columns):
+    return [CSVColumn(
+        label=COLUMNS_DISPLAY_NAMES.get(c.name) if c.name in COLUMNS_DISPLAY_NAMES else c.name,
+        model_column=c.name if c.name in COLUMNS_DISPLAY_NAMES else None,
+        blank=c in COLUMNS_DISPLAY_NAMES)
+            for c in columns]

--- a/app/api/csv_columns.py
+++ b/app/api/csv_columns.py
@@ -78,8 +78,7 @@ US_CURRENT_COLUMNS = [
 ]
 
 
-US_DAILY_COLUMNS = [CoreData.date, Literal("states")] + US_CURRENT_COLUMNS
-
+US_DAILY_COLUMNS = [ CoreData.date, Literal("states") ] + US_CURRENT_COLUMNS
 
 
 STATES_CURRENT = [
@@ -95,7 +94,6 @@ STATES_CURRENT = [
     CoreData.onVentilatorCumulative,
     CoreData.recovered,
     CoreData.death,
-
 
     Literal("lastUpdateEt"),
     #CoreData.lastUpdateEt,


### PR DESCRIPTION
There are 2 commits here that do the following:
**1st commit** Handles CSV columns, just a bit of organization -- moving the columns for each endpoint to a separate file, and uses the ORM columns (+ cheating for hybrid stuff) so if columns are renamed or changed, it'll be easy to find the names to change.
There's also a single mapping for API names to long names (it's kinda ugly now, because it does use strings, I'd want to change it later).

**2nd commit** updates the the query to fetch state daily data, by adding a limit to the number of most recent days fetched for each state.
This in turn is used for the "daily" vs "current" endpoints, and also for the new "internal/daily" endpoint, that just fetches everything for the most recent `n` days, to be used for our internal uses. This does not rename columns or anything like that (it can include unpublished columns, or maybe other internal things, no point renaming to long names here)