### PR TITLE
[CSV] Add TTR column to us daily csv

### DIFF
--- a/app/api/csv_columns.py
+++ b/app/api/csv_columns.py
@@ -80,7 +80,10 @@ US_CURRENT_COLUMNS = [
 ]
 
 
-US_DAILY_COLUMNS = [CoreData.date, Literal("states")] + US_CURRENT_COLUMNS
+
+US_DAILY_COLUMNS = [ CoreData.date, Literal("states") ] \
+    + US_CURRENT_COLUMNS \
+    + [ Literal("totalTestResults") ]
 
 
 STATES_CURRENT = [

--- a/tests/app/csv_test.py
+++ b/tests/app/csv_test.py
@@ -119,11 +119,13 @@ def test_get_us_states_csv(app, headers):
     assert data[0]["States"] == "2"
     assert data[0]["Positive"] == "30"
     assert data[0]["Negative"] == "15"
+    assert data[0]["Total Test Results"] == "45"
 
     assert data[1]["Date"] == '20200524'
     assert data[1]["States"] == "2"
     assert data[1]["Positive"] == "24"
     assert data[1]["Negative"] == "12"
+    assert data[0]["Total Test Results"] == "45"
 
     # test states current CSV
     resp = client.get("/api/v1/public/states/current.csv")


### PR DESCRIPTION
There should be only 1 commit in this PR. This actually sits on top of https://github.com/COVID19Tracking/covid-publishing-api/pull/178, and I'll clean it up after #178 is merged.

This is very simple -- add "Total Test Results" to the CSV for us/daily.csv 