### PR TITLE
[csv] give dateChecked a long display name

### DIFF
--- a/app/api/csv_columns.py
+++ b/app/api/csv_columns.py
@@ -62,6 +62,7 @@ COLUMNS_DISPLAY_NAMES = {
     "positiveTestsAntigen": "Positive Antigen Tests",
     "negativeTestsAntigen": "Negative Antigen Tests",
     "totalTestResults": "Total Test Results",
+    "dateChecked": "Check Time (ET)",
 }
 
 


### PR DESCRIPTION
I forgot to give `dateChecked` a display name for the CSV headers in the previous commit