### PR TITLE
[batches] make batch min/max edit dates date-strings instead of timesstamp

### DIFF
--- a/app/models/data.py
+++ b/app/models/data.py
@@ -65,13 +65,15 @@ class Batch(db.Model, DataMixin):
     def changedDatesMin(self):
         if not self.coreData:
             return None
-        return min(d.date for d in self.coreData)
+        d = min(d.date for d in self.coreData)
+        return str(d)
 
     @hybrid_property
     def changedDatesMax(self):
         if not self.coreData:
             return None
-        return max(d.date for d in self.coreData)
+        d = max(d.date for d in self.coreData)
+        return str(d)
 
     # This method isn't used when the object is read from the DB; only when a new one is being
     # created, as from a POST JSON payload.

--- a/tests/app/edit_test.py
+++ b/tests/app/edit_test.py
@@ -215,8 +215,8 @@ def test_edit_core_data_from_states_daily(app, headers, slack_mock, requests_moc
         # in the returned JSON
         assert 'positive' in batch_obj.changedFields
         assert 'inIcuCurrently' in batch_obj.changedFields
-        assert batch_obj.changedDatesMin == datetime.date(2020,5,24)
-        assert batch_obj.changedDatesMax == datetime.date(2020,5,24)
+        assert batch_obj.changedDatesMin == '2020-05-24'
+        assert batch_obj.changedDatesMax == '2020-05-24'
         assert batch_obj.numRowsEdited == 1
 
     # getting the states daily for NY has the edited data for yesterday and unchanged for today,


### PR DESCRIPTION
The `date` type is formatted as full timestamp on the `json` response. This is kinda useless, especially since the date here represents the `CoreData.date` field, which is only date and always presented as date string.
Just stringify the field