### PR TITLE
fix: correctly handle multiple states edit in single request

### DIFF
--- a/app/api/common.py
+++ b/app/api/common.py
@@ -16,7 +16,9 @@ def states_daily_query(state=None, preview=False, limit=None):
     # first retrieve latest published batch per state
     filter_list = [Batch.dataEntryType.in_(['daily', 'edit'])]
     if state is not None:
-        filter_list.append(CoreData.state == state)
+        if isinstance(state, str):
+            state = [state]
+        filter_list.append(CoreData.state.in_(state))
 
     if preview:
         filter_list.append(Batch.isPublished == False)

--- a/tests/app/edit_test.py
+++ b/tests/app/edit_test.py
@@ -77,9 +77,12 @@ def test_edit_core_data(app, headers, slack_mock, requests_mock):
     webhook_url = 'http://example.com/web/hook'
     app.config['API_WEBHOOK_URL'] = webhook_url
     requests_mock.get(webhook_url, json={'it': 'worked'})
+    # partial edit:
+    edit = edit_push_ny_yesterday()
+    edit['coreData'][0].pop('negative')
     resp = client.post(
         "/api/v1/batches/edit",
-        data=json.dumps(edit_push_ny_yesterday()),
+        data=json.dumps(edit),
         content_type='application/json',
         headers=headers)
     assert resp.status_code == 201


### PR DESCRIPTION
The method that handles editing, compares existing data to the submitted request.
It didn't handle the case of not specifying single state correctly (e.g., the "edit" vs "edit_states_daily" behaviour). Fixed it, updated tests a bit to fail in this case.