### PR TITLE
logging: remove default flask handler, update format

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -24,8 +24,6 @@ from app.utils.webhook import notify_webhook
 
 @api.route('/test', methods=['GET'])
 def get_data():
-    flask.current_app.logger.info('Retrieving all data: placeholder')
-    flask.current_app.logger.debug('This is a debug log')
     return flask.jsonify({'test_data_key': 'test_data_value'})
 
 

--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -21,8 +21,7 @@ if not os.path.exists(log_folder_path):
 log_file_path = os.path.join(log_folder_path, 'log.out')
 
 # Configure logger format
-log_fmt = '%(threadName)s - %(asctime)s - %(name)s - ' \
-          '%(levelname)s - %(message)s'
+log_fmt = '%(levelname).1s%(asctime)s [%(filename)s:%(lineno)d] %(message)s'
 
 logger_formatter = logging.Formatter(log_fmt)
 

--- a/config.py
+++ b/config.py
@@ -37,6 +37,7 @@ class LocalPSQLConfig:
         # INFO level or DEBUG level logs, you need to lower the main loggers
         # level first.
         app.logger.setLevel(logging.DEBUG)
+        app.logger.handlers.clear()
         app.logger.addHandler(file_logger)
         app.logger.addHandler(client_logger)
 
@@ -69,6 +70,7 @@ class Production:
         # INFO level or DEBUG level logs, you need to lower the main loggers
         # level first.
         app.logger.setLevel(logging.DEBUG)
+        app.logger.handlers.clear()
         app.logger.addHandler(file_logger)
         app.logger.addHandler(client_logger)
 
@@ -106,6 +108,7 @@ class Testing:
         # INFO level or DEBUG level logs, you need to lower the main loggers
         # level first.
         app.logger.setLevel(logging.DEBUG)
+        app.logger.handlers.clear()
         app.logger.addHandler(file_logger)
         app.logger.addHandler(client_logger)
 
@@ -140,5 +143,6 @@ class Develop:
     def init_app(app):
         """Initiates application."""
         app.logger.setLevel(logging.DEBUG)
+        app.logger.handlers.clear()
         app.logger.addHandler(client_logger)
         app.logger.addHandler(file_logger)


### PR DESCRIPTION
We have multiple handlers on our flask loggers, so log lines appear multiple times. 
This PR removes the default flask one, in favour of our custom handler. It also removes the 2 lines from the `/test` endpoint, because it's too noisy.

In a next PR:
- We should remove the FileHandler from everything other than local testing, because we don't get it through beanstalk anyways
- Review logging and levels