### PR TITLE
Update Slack notification text for push/publish

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -72,7 +72,7 @@ def publish_batch(id):
     db.session.add(batch)
     db.session.commit()
 
-    notify_slack(f"*Published batch #{id}* (type: {batch.dataEntryType})\n"
+    notify_slack(f"*Published batch #{id}* (button 2 pressed) (type: {batch.dataEntryType})\n"
                  f"{batch.batchNote}")
 
     return flask.jsonify(batch.to_dict()), 201
@@ -213,7 +213,7 @@ def post_core_data():
     status_code = post_result[1]
     if status_code == 201:
         batch_info = post_result[0].json['batch']
-        notify_slack(f"*Pushed batch #{batch_info['batchId']}* (type: {batch_info['dataEntryType']}, user: {batch_info['shiftLead']})\n"
+        notify_slack(f"*Pushed batch #{batch_info['batchId']}* (button 1 pressed) (type: {batch_info['dataEntryType']}, user: {batch_info['shiftLead']})\n"
                      f"{batch_info['batchNote']}")
 
     return post_result


### PR DESCRIPTION
Just a string change to add the button number to the Slack notification on pubshift push/publish, [as suggested by Brandon ](https://covid-tracking.slack.com/archives/G01041U0JUS/p1603917140386400?thread_ts=1603915828.384300&cid=G01041U0JUS)