### PR TITLE
Add US Daily APIv2 endpoints, and a bunch of associated refactoring

### DIFF
--- a/app/api/mappings_v2.py
+++ b/app/api/mappings_v2.py
@@ -1,0 +1,126 @@
+"""Column mappings defined for API v2. """
+
+import copy
+
+
+# The leaves are CoreData attributes that should be used to populate these values.
+_MAPPING = {
+    'cases': {
+        'total': 'positive',
+        'confirmed': 'positiveCasesViral',
+        'probable': 'probableCases',
+    },
+    'tests': {
+        'pcr': {
+            'total': 'totalTestsViral',
+            'pending': 'pending',
+            'encounters': {
+                'total': 'totalTestEncountersViral',
+            },
+            'specimens': {
+                'total': 'totalTestsViral',
+                'positive': 'positiveTestsViral',
+                'negative': 'negativeTestsViral',
+            },
+            'people': {
+                'total': 'totalTestsPeopleViral',
+                'positive': 'positive',
+                'negative': 'negative',
+            }
+        },
+        'antibody': {
+            'encounters': {
+                'total': 'totalTestsAntibody',
+                'positive': 'positiveTestsAntibody',
+                'negative': 'negativeTestsAntibody',
+            },
+            'people': {
+                'total': 'totalTestsPeopleAntibody',
+                'positive': 'positiveTestsPeopleAntibody',
+                'negative': 'negativeTestsPeopleAntibody',
+            }
+        },
+        'antigen': {
+            'encounters': {
+                'total': 'totalTestsAntigen',
+                'positive': 'positiveTestsAntigen',
+                'negative': 'negativeTestsAntigen',
+            },
+            'people': {
+                'total': 'totalTestsPeopleAntigen',
+                'positive': 'positiveTestsPeopleAntigen',
+                'negative': 'negativeTestsPeopleAntigen',
+            }
+        }
+    },
+    'outcomes': {
+        'recovered': 'recovered',
+        'hospitalized': {
+            'total': 'hospitalizedCumulative',
+            'currently': 'hospitalizedCurrently',
+            'in_icu': {
+                'total': 'inIcuCumulative',
+                'currently': 'inIcuCurrently',
+            },
+            'on_ventilator': {
+                'total': 'onVentilatorCumulative',
+                'currently': 'onVentilatorCurrently',
+            }
+        },
+        'death': {
+            'total': 'death',
+            'confirmed': 'deathConfirmed',
+            'probable': 'deathProbable',
+        }
+    }
+}
+
+
+# Similar to _MAPPING, the leaves are State attributes that should be used to populate these values.
+# The only exception is the "label" key/value pairs: these are string literals that will be
+# propagated as is to the final output.
+_STATE_INFO_MAPPING = {
+    'name': 'name',
+    'state_code': 'state',
+    'fips': 'fips',
+    'sites': [
+        {
+            'url': 'covid19Site',
+            'label': 'primary'
+        }, {
+            'url': 'covid19SiteSecondary',
+            'label': 'secondary'
+        }, {
+            'url': 'covid19SiteTertiary',
+            'label': 'tertiary'
+        }, {
+            'url': 'covid19SiteQuaternary',
+            'label': 'quaternary'
+        }, {
+            'url': 'covid19SiteQuinary',
+            'label': 'quinary'
+        },
+    ],
+    'census': {
+        'population': 'population',
+    },
+    'field_sources': {
+        'tests': {
+            'pcr': {
+                'total': 'totalTestResultsField',
+            }
+        }
+    },
+    'covid_tracking_project': {
+        'preferred_total_test': {
+            'field': 'covidTrackingProjectPreferredTotalTestField',
+            'units': 'covidTrackingProjectPreferredTotalTestUnits',
+        }
+    }
+}
+
+
+# US daily data needs its own mapping in order to propagate the logic to compute totalTestResults
+# for each state, since it's going to be handled by that state.
+_US_MAPPING = copy.deepcopy(_MAPPING)
+_US_MAPPING['tests']['pcr']['total'] = 'totalTestResults'

--- a/app/models/data.py
+++ b/app/models/data.py
@@ -268,6 +268,10 @@ class CoreData(db.Model, DataMixin):
 
         return colnames
 
+    @staticmethod
+    def stringify(timestamp):
+        return timestamp.astimezone(pytz.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
     @hybrid_property
     def lastUpdateEt(self):
         # convert lastUpdateTime (UTC) to ET, return a string that matches how we're outputting


### PR DESCRIPTION
- Mappings go into their own file to avoid clutter
- Labeling sections of the API v2 Python file for easier nav
- Since States daily returns CoreData and US daily returns dicts, needed to generalize some functions
- Unrelated: moving `data_quality_grade` into the date-specific metadata section (but it still remains a timeseries, since attached to a date)