### PR TITLE
[csv] add option to limit the number of days returned in `states/daily.csv` call

### DIFF
--- a/app/api/csv.py
+++ b/app/api/csv.py
@@ -118,10 +118,11 @@ def get_latest_states_daily_csv():
 def get_states_daily_csv():
     flask.current_app.logger.info('Retrieving States Daily')
     include_preview = request.args.get('preview', default=False, type=inputs.boolean)
+    days = request.args.get('days', default=0, type=inputs.positive)
 
-    limit = None
     if request.endpoint == 'api.states_current':
-        limit = 1
+        days = 1
+    limit = None if days == 0 else days
     states_data = get_states_daily_data(include_preview, limit)
 
     columns = STATES_CURRENT

--- a/tests/app/csv_test.py
+++ b/tests/app/csv_test.py
@@ -88,6 +88,25 @@ def test_get_states_daily_csv(app, headers):
     assert data[56]["Positive"] == "709"
     assert data[56]["Negative"] == "80477"
 
+    # tests limit number of days with public states daily
+    days = 1
+    resp = client.get("/api/v1/public/states/daily.csv?days={}".format(days))
+    assert resp.status_code == 200
+    lines = resp.data.decode("utf-8").splitlines()
+    assert len(lines) == 56 * days + 1
+    reader = csv.DictReader(lines, delimiter=',')
+    data = list(reader)
+    assert data[0]["Date"] == '20200618'
+    assert data[0]["Positive"] == "708"
+    assert data[0]["Negative"] == "80477"
+
+    # return all days when requesting 0 days
+    days = 0
+    resp = client.get("/api/v1/public/states/daily.csv?days={}".format(days))
+    assert resp.status_code == 200
+    lines = resp.data.decode("utf-8").splitlines()
+    assert len(lines) == 56 * 2 + 1
+
 
 def test_get_us_states_csv(app, headers):
     test_data = daily_push_ny_wa_two_days()


### PR DESCRIPTION
This adds the parameter `days` to `api/v1/public/states/daily.csv` call.  This also does not add a similar `days` parameter to the us/daily call. Because the US call will not be blocked by the same issue that causes problems with `states/daily` now.

This PR *does not* change the default, that will still return alllll days we have in the DB

A next PR, will unify the `days` parameter across all calls and also add a default value that will limit the number of returned lines, because returning everything all the time is not a common use case.
