### PR TITLE
Updating what we serve in US counts in API v2.0

### DIFF
--- a/app/api/mappings_v2.py
+++ b/app/api/mappings_v2.py
@@ -12,7 +12,7 @@ _MAPPING = {
     },
     'tests': {
         'pcr': {
-            'total': 'totalTestsViral',
+            'total': 'totalTestResults',
             'pending': 'pending',
             'encounters': {
                 'total': 'totalTestEncountersViral',
@@ -120,7 +120,29 @@ _STATE_INFO_MAPPING = {
 }
 
 
-# US daily data needs its own mapping in order to propagate the logic to compute totalTestResults
+# US daily data is a small subset of state data. The total test count will be a sum of each state's
+# "totalTestResults" entry.
 # for each state, since it's going to be handled by that state.
-_US_MAPPING = copy.deepcopy(_MAPPING)
-_US_MAPPING['tests']['pcr']['total'] = 'totalTestResults'
+
+_US_MAPPING = {
+    'cases': {
+        'total': 'positive',
+    },
+    'testing': {
+        'total': 'totalTestResults',
+    },
+    'outcomes': {
+        'hospitalized': {
+            'currently': 'hospitalizedCurrently',
+            'in_icu': {
+                'currently': 'inIcuCurrently',
+            },
+            'on_ventilator': {
+                'currently': 'onVentilatorCurrently',
+            }
+        },
+        'death': {
+            'total': 'death',
+        }
+    }
+}

--- a/tests/app/public_v2_test.py
+++ b/tests/app/public_v2_test.py
@@ -179,21 +179,17 @@ def test_get_us_daily(app, headers):
     first_data = resp.json['data'][0]
     assert first_data['date'] == '2020-05-25'
     assert first_data['states'] == 2
-    assert first_data['tests']['pcr']['people']['positive']['value'] == 30
-    assert first_data['tests']['pcr']['people']['negative']['value'] == 15
-    assert first_data['tests']['pcr']['total']['value'] == 45
+    assert first_data['testing']['total']['value'] == 45
 
     # make sure calculated values are correct
-    assert first_data['tests']['pcr']['people']['positive']['calculated'] == {
+    assert first_data['testing']['total']['calculated'] == {
         'population_percent': 0.0,
-        'change_from_prior_day': 6,
-        'seven_day_average': 27,
+        'change_from_prior_day': 9,
+        'seven_day_average': 40,
         'seven_day_change_percent': None,
     }
 
     second_data = resp.json['data'][1]
     assert second_data['date'] == '2020-05-24'
     assert second_data['states'] == 2
-    assert second_data['tests']['pcr']['people']['positive']['value'] == 24
-    assert second_data['tests']['pcr']['people']['negative']['value'] == 12
-    assert second_data['tests']['pcr']['total']['value'] == 36
+    assert second_data['testing']['total']['value'] == 36


### PR DESCRIPTION
Also, changing the *States Daily* source for tests.pcr.total: totalTestsViral -> totalTestResults, for consistency with US Daily. @kevee CCing you just in case