### PR TITLE
[small] do not force updating states when sending a new batch

### DIFF
--- a/app/api/data.py
+++ b/app/api/data.py
@@ -151,8 +151,8 @@ def post_core_data_json(payload):
     db.session.add(batch)
     db.session.flush()  # this sets the batch ID, which we need for corresponding coreData objects
 
-    # add states
-    state_dicts = payload['states']
+    # add states if exist
+    state_dicts = payload.get('states', [])
     state_objects = []
     for state_dict in state_dicts:
         state_pk = state_dict['state']

--- a/app/utils/validation.py
+++ b/app/utils/validation.py
@@ -49,13 +49,14 @@ def validate_core_data_payload(payload):
     # test the input data
     if 'context' not in payload:
         raise ValueError("Payload requires 'context' field")
-    if 'states' not in payload or not payload['states']:
+    if ('states' not in payload or not payload['states']) and \
+        (payload['context']['dataEntryType'] != 'research'):
         raise ValueError("Payload requires 'states' field with at least one entry")
     if 'coreData' not in payload or not payload['coreData']:
         raise ValueError("Payload requires 'coreData' field with at least one entry")
 
     validate_numeric_fields(payload)
-    validate_non_empty_fields(payload)    
+    validate_non_empty_fields(payload)
     validate_no_unknown_fields(payload)
 
 


### PR DESCRIPTION
This PR just removes the validation that forces updating states matadata when sending a new batch.
This will still validate that all the states in `coreData` are valid -- exist in the states we know about.